### PR TITLE
Update checkout and setup-java actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,25 +18,15 @@ jobs:
         scala: [2.12.17, 2.13.10, 3.2.2]        
         platform: [ubuntu-20.04]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
-          lfs: true
+          fetch-depth: 0
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: temurin
           java-version: ${{ matrix.java }}
-
-      - name: Cache maven packages
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-sbt
-        with:
-          path: ~/.m2 ~/.coursier ~/.cache/coursier ~/.ivy2 ~/.sbt
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          cache: sbt
       - name: Compile Docs
         if: ${{ matrix.java == '11' }}
         run: JAVA_OPTS="--add-opens java.base/java.lang=ALL-UNNAMED" sbt "++ ${{ matrix.scala }} mdoc"


### PR DESCRIPTION
`setup-java` now takes care of caching.
This simplifies the workflow.