### PR TITLE
Fix compilation when using Scala 3.3.x. 

### DIFF
--- a/src/main/scala/org/apache/flink/api/serializer/MappedSerializer.scala
+++ b/src/main/scala/org/apache/flink/api/serializer/MappedSerializer.scala
@@ -53,7 +53,7 @@ object MappedSerializer {
     override def readSnapshot(readVersion: Int, in: DataInputView, userCodeClassLoader: ClassLoader): Unit = {
       val mapperClazz = InstantiationUtil.resolveClassByName[TypeMapper[A, B]](in, userCodeClassLoader)
       mapper = InstantiationUtil.instantiate(mapperClazz)
-      val serClazz = InstantiationUtil.resolveClassByName(in, userCodeClassLoader)
+      val serClazz = InstantiationUtil.resolveClassByName[TypeSerializer[B]](in, userCodeClassLoader)
       ser = InstantiationUtil.instantiate(serClazz)
     }
 


### PR DESCRIPTION
Lack of explicit type hint leads to undefined type inference which was not previously reported. Specification of language does not define what type should be infered in such case. Depending on Scala version infered type can be either Any or Nothing. 