### PR TITLE
Ignore scala steward for flink itself

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,3 @@
+updates.ignore = [
+  { groupId = "org.apache.flink" }
+]


### PR DESCRIPTION
We are not interested in scala steward updates for flink itself, because we are cross building for multiple versions.

To prevent more like

* #20

in the future