### PR TITLE
Remove sbt-updates

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,6 @@
 addSbtPlugin("org.xerial.sbt"   % "sbt-sonatype" % "3.9.21")
 addSbtPlugin("com.github.sbt"   % "sbt-pgp"      % "2.1.2")
 addSbtPlugin("org.scalameta"    % "sbt-scalafmt" % "2.5.0")
-addSbtPlugin("com.timushev.sbt" % "sbt-updates"  % "0.6.4")
 addSbtPlugin("com.github.sbt"   % "sbt-release"  % "1.1.0")
 addSbtPlugin("org.scalameta"    % "sbt-mdoc"     % "2.2.24")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git"      % "1.0.2")


### PR DESCRIPTION
We have scala steward providing us with pull request, we no longer need `sbt-updates` plugin

See: https://github.com/VirtusLab/scala-steward-repos/pull/234