### PR TITLE
Make TypeMapper trait serializable

### DIFF
--- a/src/main/scala/org/apache/flinkx/api/serializer/MappedSerializer.scala
+++ b/src/main/scala/org/apache/flinkx/api/serializer/MappedSerializer.scala
@@ -37,7 +37,7 @@ case class MappedSerializer[A, B](mapper: TypeMapper[A, B], ser: TypeSerializer[
 }
 
 object MappedSerializer {
-  trait TypeMapper[A, B] {
+  trait TypeMapper[A, B] extends Serializable {
     def map(a: A): B
     def contramap(b: B): A
   }

--- a/src/test/scala/org/apache/flinkx/api/MappedTypeInfoTest.scala
+++ b/src/test/scala/org/apache/flinkx/api/MappedTypeInfoTest.scala
@@ -11,7 +11,7 @@ import scala.reflect.ClassTag
 
 class MappedTypeInfoTest extends AnyFlatSpec with Matchers with TestUtils {
   import MappedTypeInfoTest._
-  it should "derive TI for non-serializeable classes" in {
+  it should "derive TI for non-serializable classes" in {
     drop(implicitly[TypeInformation[WrappedString]])
   }
 }


### PR DESCRIPTION
Should solve https://github.com/flink-extended/flink-scala-api/issues/81

I am not entirely sure if the spec spinning the whole execution environment is supposed to be under the mapped type info test, but it felt like the right place because of the problem scope. Let me know if something needs fixing.