### PR TITLE
Fix unstable integration tests

### DIFF
--- a/src/test/scala/org/apache/flinkx/api/ExampleTest.scala
+++ b/src/test/scala/org/apache/flinkx/api/ExampleTest.scala
@@ -1,50 +1,17 @@
 package org.apache.flinkx.api
 
-import org.apache.flinkx.api.serializers._
-import org.apache.flink.api.common.RuntimeExecutionMode
-import org.apache.flink.api.common.restartstrategy.RestartStrategies
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration
-import org.apache.flink.streaming.api.datastream.DataStreamSource
-import org.apache.flink.test.util.MiniClusterWithClientResource
-import org.scalatest.BeforeAndAfterAll
+import org.apache.flinkx.api.serializers._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.annotation.nowarn
-
-class ExampleTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+class ExampleTest extends AnyFlatSpec with Matchers with IntegrationTest {
   import ExampleTest._
-
-  lazy val cluster = new MiniClusterWithClientResource(
-    new MiniClusterResourceConfiguration.Builder().setNumberSlotsPerTaskManager(1).setNumberTaskManagers(1).build()
-  )
-
-  lazy val env: StreamExecutionEnvironment = {
-    cluster.getTestEnvironment.setAsContext()
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    env.setParallelism(1)
-    env.setRuntimeMode(RuntimeExecutionMode.STREAMING)
-    env.enableCheckpointing(1000)
-    env.setRestartStrategy(RestartStrategies.noRestart())
-    env.getConfig.disableGenericTypes()
-    env
-  }
-
-  override protected def beforeAll(): Unit = {
-    super.beforeAll()
-    cluster.before()
-  }
-
-  override def afterAll(): Unit = {
-    cluster.after()
-    super.afterAll()
-  }
 
   it should "run example code" in {
     val result = env
-      .fromScalaCollection(List(Event.Click("1"), Event.Purchase(1.0)))
-      .executeAndCollect(10)
+      .fromCollection(List(Event.Click("1"), Event.Purchase(1.0)))
+      .collect()
 
     result.size shouldBe 2
   }
@@ -58,13 +25,5 @@ object ExampleTest {
     final case class Purchase(price: Double) extends Event
 
     implicit val eventTypeInfo: TypeInformation[Event] = deriveTypeInformation[Event]
-  }
-
-  implicit final class EnvOps(private val env: StreamExecutionEnvironment) extends AnyVal {
-    import scala.collection.JavaConverters._
-
-    @nowarn("cat=deprecation")
-    def fromScalaCollection[A](data: Seq[A])(implicit typeInformation: TypeInformation[A]): DataStreamSource[A] =
-      env.getJavaEnv.fromCollection(data.asJava, typeInformation)
   }
 }

--- a/src/test/scala/org/apache/flinkx/api/IntegrationTest.scala
+++ b/src/test/scala/org/apache/flinkx/api/IntegrationTest.scala
@@ -1,0 +1,47 @@
+package org.apache.flinkx.api
+
+import org.apache.flink.api.common.RuntimeExecutionMode
+import org.apache.flink.api.common.restartstrategy.RestartStrategies
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration
+import org.apache.flink.test.util.MiniClusterWithClientResource
+import org.scalatest.{BeforeAndAfterEach, Suite}
+
+trait IntegrationTest extends BeforeAndAfterEach {
+  this: Suite =>
+
+  lazy val cluster = new MiniClusterWithClientResource(
+    new MiniClusterResourceConfiguration.Builder().setNumberSlotsPerTaskManager(1).setNumberTaskManagers(1).build()
+  )
+
+  lazy val env: StreamExecutionEnvironment = {
+    cluster.getTestEnvironment.setAsContext()
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setParallelism(1)
+    env.setRuntimeMode(RuntimeExecutionMode.STREAMING)
+    env.enableCheckpointing(1000)
+    env.setRestartStrategy(RestartStrategies.noRestart())
+    env.getConfig.disableGenericTypes()
+    env
+  }
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    cluster.before()
+    IntegrationTestSink.values.clear()
+  }
+
+  override def afterEach(): Unit = {
+    cluster.after()
+    super.afterEach()
+  }
+
+  implicit final class DataStreamOps[T](private val dataStream: DataStream[T]) {
+    import scala.collection.JavaConverters._
+
+    def collect(): List[T] = {
+      dataStream.addSink(new IntegrationTestSink[T])
+      env.execute()
+      IntegrationTestSink.values.asScala.toList.map(_.asInstanceOf[T])
+    }
+  }
+}

--- a/src/test/scala/org/apache/flinkx/api/IntegrationTestSink.scala
+++ b/src/test/scala/org/apache/flinkx/api/IntegrationTestSink.scala
@@ -1,0 +1,11 @@
+package org.apache.flinkx.api
+
+import org.apache.flink.streaming.api.functions.sink.SinkFunction
+
+class IntegrationTestSink[T] extends SinkFunction[T] {
+  override def invoke(value: T, context: SinkFunction.Context): Unit = IntegrationTestSink.values.add(value)
+}
+
+object IntegrationTestSink {
+  val values: java.util.List[Any] = java.util.Collections.synchronizedList(new java.util.ArrayList())
+}


### PR DESCRIPTION
I'm after https://github.com/flink-extended/flink-scala-api/issues/70, this is the only test that had `.executeAndCollect` at the time of reporting and it's only one that has tested an actual flink job. I've been successfully testing flink jobs based on recommendations from https://nightlies.apache.org/flink/flink-docs-master/docs/dev/datastream/testing/#testing-flink-jobs.

The `.executeAndCollect()` executed the job but pulls everything using the RESTful API and I suspect that's where the issue comes from.

I'm marking this is a draft to make sure it's worth continuing.