### PR TITLE
Stabilize tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,9 +17,7 @@ lazy val root = (project in file("."))
       "org.apache.flink"  % "flink-streaming-java"   % flinkVersion,
       "org.apache.flink"  % "flink-java"             % flinkVersion,
       "org.apache.flink"  % "flink-test-utils"       % flinkVersion % Test,
-      "org.apache.flink"  % "flink-test-utils-junit" % flinkVersion % Test,
       ("org.apache.flink" % "flink-streaming-java"   % flinkVersion % Test).classifier("tests"),
-      "com.github.sbt"    % "junit-interface"        % "0.13.3"     % Test,
       "org.typelevel"    %% "cats-core"              % "2.10.0"     % Test,
       "org.scalatest"    %% "scalatest"              % "3.2.18"     % Test
     ),

--- a/src/test/scala/org/apache/flinkx/api/CoGroupedStreamsTest.scala
+++ b/src/test/scala/org/apache/flinkx/api/CoGroupedStreamsTest.scala
@@ -1,48 +1,27 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.apache.flinkx.api
 
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows
 import org.apache.flink.streaming.api.windowing.time.Time
-import org.junit.{Assert, Test}
 import org.apache.flinkx.api.serializers._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-/** Unit test for [[org.apache.flink.streaming.api.scala.CoGroupedStreams]]
-  */
-class CoGroupedStreamsTest {
-  private val env = StreamExecutionEnvironment.getExecutionEnvironment
-
+class CoGroupedStreamsTest extends AnyFlatSpec with Matchers with IntegrationTest {
   private val dataStream1 = env.fromElements("a1", "a2", "a3")
   private val dataStream2 = env.fromElements("a1", "a2")
   private val keySelector = (s: String) => s
   private val tsAssigner  = TumblingEventTimeWindows.of(Time.milliseconds(1))
 
-  @Test
-  def testSetAllowedLateness(): Unit = {
+  it should "set allowed lateness" in {
     val lateness = Time.milliseconds(42)
+
     val withLateness = dataStream1
       .coGroup(dataStream2)
       .where(keySelector)
       .equalTo(keySelector)
       .window(tsAssigner)
       .allowedLateness(lateness)
-    Assert.assertEquals(lateness.toMilliseconds, withLateness.allowedLateness.toMilliseconds)
-  }
 
+    withLateness.allowedLateness.toMilliseconds shouldBe lateness.toMilliseconds
+  }
 }

--- a/src/test/scala/org/apache/flinkx/api/ExampleTest.scala
+++ b/src/test/scala/org/apache/flinkx/api/ExampleTest.scala
@@ -1,52 +1,26 @@
 package org.apache.flinkx.api
 
-import org.apache.flinkx.api.serializers._
-import org.apache.flink.api.common.RuntimeExecutionMode
-import org.apache.flink.api.common.restartstrategy.RestartStrategies
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration
-import org.apache.flink.streaming.api.datastream.DataStreamSource
-import org.apache.flink.test.util.MiniClusterWithClientResource
-import org.scalatest.BeforeAndAfterAll
+import org.apache.flinkx.api.serializers._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.annotation.nowarn
+import java.util.UUID
 
-class ExampleTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+class ExampleTest extends AnyFlatSpec with Matchers with IntegrationTest {
   import ExampleTest._
 
-  lazy val cluster = new MiniClusterWithClientResource(
-    new MiniClusterResourceConfiguration.Builder().setNumberSlotsPerTaskManager(1).setNumberTaskManagers(1).build()
-  )
-
-  lazy val env: StreamExecutionEnvironment = {
-    cluster.getTestEnvironment.setAsContext()
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    env.setParallelism(1)
-    env.setRuntimeMode(RuntimeExecutionMode.STREAMING)
-    env.enableCheckpointing(1000)
-    env.setRestartStrategy(RestartStrategies.noRestart())
-    env.getConfig.disableGenericTypes()
-    env
-  }
-
-  override protected def beforeAll(): Unit = {
-    super.beforeAll()
-    cluster.before()
-  }
-
-  override def afterAll(): Unit = {
-    cluster.after()
-    super.afterAll()
-  }
-
-  it should "run example code" in {
+  it should "serialize elements with type mappers across operators" in {
     val result = env
-      .fromScalaCollection(List(Event.Click("1"), Event.Purchase(1.0)))
-      .executeAndCollect(10)
+      .fromElements(
+        Event.View(UUID.randomUUID()),
+        Event.Click("1"),
+        Event.Purchase(1.0)
+      )
+      .keyBy(_.hashCode)
+      .collect()
 
-    result.size shouldBe 2
+    result should have size 3
   }
 }
 
@@ -54,17 +28,10 @@ object ExampleTest {
   sealed trait Event extends Product with Serializable
 
   object Event {
-    final case class Click(id: String)       extends Event
-    final case class Purchase(price: Double) extends Event
+    final case class View(id: UUID)              extends Event
+    final case class Click(id: String)           extends Event
+    final case class Purchase(price: BigDecimal) extends Event
 
     implicit val eventTypeInfo: TypeInformation[Event] = deriveTypeInformation[Event]
-  }
-
-  implicit final class EnvOps(private val env: StreamExecutionEnvironment) extends AnyVal {
-    import scala.collection.JavaConverters._
-
-    @nowarn("cat=deprecation")
-    def fromScalaCollection[A](data: Seq[A])(implicit typeInformation: TypeInformation[A]): DataStreamSource[A] =
-      env.getJavaEnv.fromCollection(data.asJava, typeInformation)
   }
 }

--- a/src/test/scala/org/apache/flinkx/api/IntegrationTest.scala
+++ b/src/test/scala/org/apache/flinkx/api/IntegrationTest.scala
@@ -1,0 +1,56 @@
+package org.apache.flinkx.api
+
+import org.apache.flink.api.common.RuntimeExecutionMode
+import org.apache.flink.api.common.restartstrategy.RestartStrategies
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration
+import org.apache.flink.test.util.MiniClusterWithClientResource
+import org.scalatest.{BeforeAndAfterEach, Suite}
+
+trait IntegrationTest extends BeforeAndAfterEach {
+  this: Suite =>
+
+  // It is recommended to always test your pipelines locally with a parallelism > 1 to identify bugs which only
+  // surface for the pipelines executed in parallel. Setting number of slots per task manager and number of task
+  // managers to 2 and parallelism to a multiple of them is a good starting point.
+  val numberSlotsPerTaskManager = 2
+  val numberTaskManagers        = 2
+  val parallelism: Int          = numberSlotsPerTaskManager * numberTaskManagers
+
+  val cluster = new MiniClusterWithClientResource(
+    new MiniClusterResourceConfiguration.Builder()
+      .setNumberSlotsPerTaskManager(numberSlotsPerTaskManager)
+      .setNumberTaskManagers(numberTaskManagers)
+      .build()
+  )
+
+  val env: StreamExecutionEnvironment = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setParallelism(parallelism)
+    env.setRuntimeMode(RuntimeExecutionMode.STREAMING)
+    env.enableCheckpointing(1000)
+    env.setRestartStrategy(RestartStrategies.noRestart())
+    env.getConfig.disableGenericTypes()
+    env
+  }
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    cluster.before()
+    IntegrationTestSink.values.clear()
+  }
+
+  override def afterEach(): Unit = {
+    cluster.after()
+    super.afterEach()
+  }
+
+  implicit final class DataStreamOps[T](private val dataStream: DataStream[T]) {
+    import scala.collection.JavaConverters._
+
+    def collect(): List[T] = {
+      dataStream.addSink(new IntegrationTestSink[T])
+      env.execute()
+      IntegrationTestSink.values.asScala.toList.map(_.asInstanceOf[T])
+    }
+  }
+}

--- a/src/test/scala/org/apache/flinkx/api/IntegrationTestSink.scala
+++ b/src/test/scala/org/apache/flinkx/api/IntegrationTestSink.scala
@@ -1,0 +1,11 @@
+package org.apache.flinkx.api
+
+import org.apache.flink.streaming.api.functions.sink.SinkFunction
+
+class IntegrationTestSink[T] extends SinkFunction[T] {
+  override def invoke(value: T, context: SinkFunction.Context): Unit = IntegrationTestSink.values.add(value)
+}
+
+object IntegrationTestSink {
+  val values: java.util.List[Any] = java.util.Collections.synchronizedList(new java.util.ArrayList())
+}

--- a/src/test/scala/org/apache/flinkx/api/JoinedStreamsTest.scala
+++ b/src/test/scala/org/apache/flinkx/api/JoinedStreamsTest.scala
@@ -1,47 +1,27 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.apache.flinkx.api
 
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows
 import org.apache.flink.streaming.api.windowing.time.Time
-import org.junit.{Assert, Test}
 import org.apache.flinkx.api.serializers._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-/** Unit test for [[org.apache.flink.streaming.api.scala.JoinedStreams]]
-  */
-class JoinedStreamsTest {
-  private val env = StreamExecutionEnvironment.getExecutionEnvironment
-
+class JoinedStreamsTest extends AnyFlatSpec with Matchers with IntegrationTest {
   private val dataStream1 = env.fromElements("a1", "a2", "a3")
   private val dataStream2 = env.fromElements("a1", "a2")
   private val keySelector = (s: String) => s
   private val tsAssigner  = TumblingEventTimeWindows.of(Time.milliseconds(1))
 
-  @Test
-  def testSetAllowedLateness(): Unit = {
+  it should "set allowed lateness" in {
     val lateness = Time.milliseconds(42)
+
     val withLateness = dataStream1
       .join(dataStream2)
       .where(keySelector)
       .equalTo(keySelector)
       .window(tsAssigner)
       .allowedLateness(lateness)
-    Assert.assertEquals(lateness.toMilliseconds, withLateness.allowedLateness.toMilliseconds)
+
+    withLateness.allowedLateness.toMilliseconds shouldBe lateness.toMilliseconds
   }
 }

--- a/src/test/scala/org/apache/flinkx/api/MappedTypeInfoTest.scala
+++ b/src/test/scala/org/apache/flinkx/api/MappedTypeInfoTest.scala
@@ -1,26 +1,15 @@
 package org.apache.flinkx.api
 
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flinkx.api.serializer.MappedSerializer.TypeMapper
+import org.apache.flinkx.api.serializers._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.apache.flinkx.api.MappedTypeInfoTest.WrappedString
-import org.apache.flinkx.api.serializers._
-import org.apache.flinkx.api.serializer.MappedSerializer.TypeMapper
-import org.apache.flink.api.common.typeinfo.TypeInformation
-
-import scala.reflect.ClassTag
 
 class MappedTypeInfoTest extends AnyFlatSpec with Matchers with TestUtils {
   import MappedTypeInfoTest._
   it should "derive TI for non-serializable classes" in {
     drop(implicitly[TypeInformation[WrappedString]])
-  }
-
-  it should "serialize type mappers across tasks" in {
-    val env        = StreamExecutionEnvironment.getExecutionEnvironment
-    val dataStream = env.fromElements(Purchase(1, 1.0))
-    val purchase   = dataStream.keyBy(_.id).map(_.copy(price = 5.1)).executeAndCollect(1)
-
-    purchase.last should be(Purchase(1, 5.1))
   }
 }
 
@@ -47,11 +36,5 @@ object MappedTypeInfoTest {
     def put(value: String) = {
       internal = value
     }
-  }
-
-  case class Purchase(id: Int, price: BigDecimal)
-
-  object Purchase {
-    implicit val typeInfo: TypeInformation[Purchase] = deriveTypeInformation
   }
 }

--- a/src/test/scala/org/apache/flinkx/api/StreamExecutionEnvironmentTest.scala
+++ b/src/test/scala/org/apache/flinkx/api/StreamExecutionEnvironmentTest.scala
@@ -1,21 +1,3 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.apache.flinkx.api
 
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
@@ -23,19 +5,13 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.connector.source.Boundedness
 import org.apache.flink.api.connector.source.mocks.MockSource
 import org.apache.flink.api.java.typeutils.GenericTypeInfo
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-/** Tests for the [[StreamExecutionEnvironment]].
-  */
-class StreamExecutionEnvironmentTest {
+class StreamExecutionEnvironmentTest extends AnyFlatSpec with Matchers with IntegrationTest {
 
-  /** Verifies that calls to fromSource() don't throw and create a stream of the expected type.
-    */
-  @Test
-  def testFromSource(): Unit = {
+  it should "create a stream from a source" in {
     implicit val typeInfo: TypeInformation[Integer] = new MockTypeInfo()
-    val env                                         = StreamExecutionEnvironment.getExecutionEnvironment
 
     val stream = env.fromSource(
       new MockSource(Boundedness.CONTINUOUS_UNBOUNDED, 1),
@@ -43,20 +19,16 @@ class StreamExecutionEnvironmentTest {
       "test source"
     )
 
-    assertEquals(typeInfo, stream.dataType)
+    stream.dataType shouldBe typeInfo
   }
 
-  /** Verifies that calls to fromSequence() instantiate a new DataStream that contains a sequence of numbers.
-    */
-  @Test
-  def testFromSequence(): Unit = {
+  it should "create a stream from a sequence" in {
     import org.apache.flinkx.api.serializers._
     val typeInfo = implicitly[TypeInformation[Long]]
-    val env      = StreamExecutionEnvironment.getExecutionEnvironment
 
     val stream = env.fromSequence(1, 100)
 
-    assertEquals(typeInfo, stream.dataType)
+    stream.dataType shouldBe typeInfo
   }
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
Addresses:
- https://github.com/flink-extended/flink-scala-api/issues/70
- https://github.com/flink-extended/flink-scala-api/issues/91

The key change is the introduction of `IntegrationTest` and `IntegrationTestSink` which are used across the whole testing suite instead of obtaining the execution environment from _somewhere_.

Given that the example test was failing and it was the only one using `.executeAndCollect()`, I suspected it could be the cause for floppiness, flink [recommends](https://nightlies.apache.org/flink/flink-docs-master/docs/dev/datastream/testing/#testing-flink-jobs) building a custom sink operator to test job outputs and I've done exactly that by implementing `IntegrationTestSink` class. I've been using exactly this kind of sink function and have never had an issue with it being flappy.

I've replaced JUnit tests with Scalatest for consistency, I've also removed JUnit from imports. It should've been possible to write more Scalatest-esque assertions but I wanted to migrate with as few diffs as possible.