### PR TITLE
Correct flink test cluster lifecycle methods

### DIFF
--- a/src/test/scala/org/apache/flinkx/api/IntegrationTest.scala
+++ b/src/test/scala/org/apache/flinkx/api/IntegrationTest.scala
@@ -4,9 +4,9 @@ import org.apache.flink.api.common.RuntimeExecutionMode
 import org.apache.flink.api.common.restartstrategy.RestartStrategies
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration
 import org.apache.flink.test.util.MiniClusterWithClientResource
-import org.scalatest.{BeforeAndAfterEach, Suite}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
 
-trait IntegrationTest extends BeforeAndAfterEach {
+trait IntegrationTest extends BeforeAndAfterEach with BeforeAndAfterAll {
   this: Suite =>
 
   // It is recommended to always test your pipelines locally with a parallelism > 1 to identify bugs which only
@@ -33,15 +33,19 @@ trait IntegrationTest extends BeforeAndAfterEach {
     env
   }
 
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    cluster.before()
+  }
+
   override protected def beforeEach(): Unit = {
     super.beforeEach()
-    cluster.before()
     IntegrationTestSink.values.clear()
   }
 
-  override def afterEach(): Unit = {
+  override def afterAll(): Unit = {
     cluster.after()
-    super.afterEach()
+    super.afterAll()
   }
 
   implicit final class DataStreamOps[T](private val dataStream: DataStream[T]) {


### PR DESCRIPTION
I've noticed that after my change test times increased. Previously, example test would call `cluster.before()` and `cluster.after()` in the before/after ALL test hook, not before each. Using it in the all lifecycle is correct because it will setup and tear down the whole cluster, which is recommended by the documentation https://nightlies.apache.org/flink/flink-docs-master/docs/dev/datastream/testing/

> Prefer @ClassRule over @Rule so that multiple tests can share the same Flink cluster. Doing so saves a significant amount of time since the startup and shutdown of Flink clusters usually dominate the execution time of the actual tests.

