### PR TITLE
Align ci and release versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,17 +16,11 @@ jobs:
       matrix:
         java: [11]
         scala: [2.12.19, 2.13.13, 3.3.3]
-        flink: [1.15.4]
+        flink: [1.16.3, 1.17.2]
         include:
           - scala: 3.3.3
-            java: 11
-            flink: 1.16.2
-          - scala: 3.3.3
-            java: 11
-            flink: 1.17.1
-          - scala: 3.3.3
             java: 17
-            flink: 1.18.0
+            flink: 1.18.1
     steps:
       - uses: actions/checkout@v3
         with:
@@ -37,8 +31,7 @@ jobs:
           distribution: temurin
           java-version: ${{ matrix.java }}
           cache: sbt
-      - name: Compile Docs        
+      - name: Compile Docs
         run: JAVA_OPTS="--add-opens java.base/java.lang=ALL-UNNAMED" sbt "++ ${{ matrix.scala }} mdoc"
-      - name: Run tests        
-        run: JAVA_OPTS="--add-opens java.base/java.lang=ALL-UNNAMED" sbt -DflinkVersion=${{ matrix.flink }} "++ ${{ matrix.scala }} test"      
-
+      - name: Run tests
+        run: JAVA_OPTS="--add-opens java.base/java.lang=ALL-UNNAMED" sbt -DflinkVersion=${{ matrix.flink }} "++ ${{ matrix.scala }} test"


### PR DESCRIPTION
Addresses the https://github.com/flink-extended/flink-scala-api/issues/99#issuecomment-1979076639, this will allow implementing async i/o retry policy given the minimum version bump.