### PR TITLE
Add async i/o with retry support

### DIFF
--- a/src/main/scala/org/apache/flinkx/api/AsyncDataStream.scala
+++ b/src/main/scala/org/apache/flinkx/api/AsyncDataStream.scala
@@ -11,11 +11,13 @@ import org.apache.flink.annotation.PublicEvolving
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.datastream.{AsyncDataStream => JavaAsyncDataStream}
 import org.apache.flink.streaming.api.functions.async.{
+  AsyncRetryStrategy => JavaAsyncRetryStrategy,
   AsyncFunction => JavaAsyncFunction,
   ResultFuture => JavaResultFuture
 }
 import org.apache.flink.util.Preconditions
 import ScalaStreamOps._
+
 import scala.concurrent.duration.TimeUnit
 
 /** A helper class to apply [[AsyncFunction]] to a data stream.
@@ -296,6 +298,331 @@ object AsyncDataStream {
   ): DataStream[OUT] = {
 
     orderedWait(input, timeout, timeUnit, DEFAULT_QUEUE_CAPACITY)(asyncFunction)
+  }
+
+  /** Apply an asynchronous function on the input data stream. The output order is only maintained with respect to
+    * watermarks. Stream records which lie between the same two watermarks, can be re-ordered.
+    *
+    * @param input
+    *   to apply the async function on
+    * @param asyncFunction
+    *   to use
+    * @param timeout
+    *   for the asynchronous operation to complete
+    * @param timeUnit
+    *   of the timeout
+    * @param capacity
+    *   of the operator which is equivalent to the number of concurrent asynchronous operations
+    * @param asyncRetryStrategy
+    *   The strategy of reattempt async i/o operation that can be triggered
+    * @tparam IN
+    *   Type of the input record
+    * @tparam OUT
+    *   Type of the output record
+    * @return
+    *   the resulting stream containing the asynchronous results
+    */
+  def unorderedWaitWithRetry[IN, OUT: TypeInformation](
+      input: DataStream[IN],
+      asyncFunction: AsyncFunction[IN, OUT],
+      timeout: Long,
+      timeUnit: TimeUnit,
+      capacity: Int,
+      asyncRetryStrategy: JavaAsyncRetryStrategy[OUT]
+  ): DataStream[OUT] = {
+
+    val javaAsyncFunction = wrapAsJavaAsyncFunction(asyncFunction)
+
+    val outType: TypeInformation[OUT] = implicitly[TypeInformation[OUT]]
+
+    asScalaStream(
+      JavaAsyncDataStream
+        .unorderedWaitWithRetry[IN, OUT](
+          input.javaStream,
+          javaAsyncFunction,
+          timeout,
+          timeUnit,
+          capacity,
+          asyncRetryStrategy
+        )
+        .returns(outType)
+    )
+  }
+
+  /** Apply an asynchronous function on the input data stream. The output order is only maintained with respect to
+    * watermarks. Stream records which lie between the same two watermarks, can be re-ordered.
+    *
+    * @param input
+    *   to apply the async function on
+    * @param asyncFunction
+    *   to use
+    * @param timeout
+    *   for the asynchronous operation to complete
+    * @param timeUnit
+    *   of the timeout
+    * @param asyncRetryStrategy
+    *   The strategy of reattempt async i/o operation that can be triggered
+    * @tparam IN
+    *   Type of the input record
+    * @tparam OUT
+    *   Type of the output record
+    * @return
+    *   the resulting stream containing the asynchronous results
+    */
+  def unorderedWaitWithRetry[IN, OUT: TypeInformation](
+      input: DataStream[IN],
+      asyncFunction: AsyncFunction[IN, OUT],
+      timeout: Long,
+      timeUnit: TimeUnit,
+      asyncRetryStrategy: JavaAsyncRetryStrategy[OUT]
+  ): DataStream[OUT] = {
+
+    unorderedWaitWithRetry(input, asyncFunction, timeout, timeUnit, DEFAULT_QUEUE_CAPACITY, asyncRetryStrategy)
+  }
+
+  /** Apply an asynchronous function on the input data stream. The output order is only maintained with respect to
+    * watermarks. Stream records which lie between the same two watermarks, can be re-ordered.
+    *
+    * @param input
+    *   to apply the async function on
+    * @param timeout
+    *   for the asynchronous operation to complete
+    * @param timeUnit
+    *   of the timeout
+    * @param capacity
+    *   of the operator which is equivalent to the number of concurrent asynchronous operations
+    * @param asyncRetryStrategy
+    *   The strategy of reattempt async i/o operation that can be triggered
+    * @param asyncFunction
+    *   to use
+    * @tparam IN
+    *   Type of the input record
+    * @tparam OUT
+    *   Type of the output record
+    * @return
+    *   the resulting stream containing the asynchronous results
+    */
+  def unorderedWaitWithRetry[IN, OUT: TypeInformation](
+      input: DataStream[IN],
+      timeout: Long,
+      timeUnit: TimeUnit,
+      capacity: Int,
+      asyncRetryStrategy: JavaAsyncRetryStrategy[OUT]
+  )(
+      asyncFunction: (IN, ResultFuture[OUT]) => Unit
+  ): DataStream[OUT] = {
+
+    Preconditions.checkNotNull(asyncFunction)
+
+    val cleanAsyncFunction = input.executionEnvironment.scalaClean(asyncFunction)
+
+    val func = new JavaAsyncFunction[IN, OUT] {
+      override def asyncInvoke(input: IN, resultFuture: JavaResultFuture[OUT]): Unit = {
+
+        cleanAsyncFunction(input, new JavaResultFutureWrapper[OUT](resultFuture))
+      }
+    }
+
+    val outType: TypeInformation[OUT] = implicitly[TypeInformation[OUT]]
+
+    asScalaStream(
+      JavaAsyncDataStream
+        .unorderedWaitWithRetry[IN, OUT](input.javaStream, func, timeout, timeUnit, capacity, asyncRetryStrategy)
+        .returns(outType)
+    )
+  }
+
+  /** Apply an asynchronous function on the input data stream. The output order is only maintained with respect to
+    * watermarks. Stream records which lie between the same two watermarks, can be re-ordered.
+    *
+    * @param input
+    *   to apply the async function on
+    * @param timeout
+    *   for the asynchronous operation to complete
+    * @param timeUnit
+    *   of the timeout
+    * @param asyncRetryStrategy
+    *   The strategy of reattempt async i/o operation that can be triggered
+    * @param asyncFunction
+    *   to use
+    * @tparam IN
+    *   Type of the input record
+    * @tparam OUT
+    *   Type of the output record
+    * @return
+    *   the resulting stream containing the asynchronous results
+    */
+  def unorderedWaitWithRetry[IN, OUT: TypeInformation](
+      input: DataStream[IN],
+      timeout: Long,
+      timeUnit: TimeUnit,
+      asyncRetryStrategy: JavaAsyncRetryStrategy[OUT]
+  )(
+      asyncFunction: (IN, ResultFuture[OUT]) => Unit
+  ): DataStream[OUT] = {
+    unorderedWaitWithRetry(input, timeout, timeUnit, DEFAULT_QUEUE_CAPACITY, asyncRetryStrategy)(asyncFunction)
+  }
+
+  /** Apply an asynchronous function on the input data stream. The output order is the same as the input order of the
+    * elements.
+    *
+    * @param input
+    *   to apply the async function on
+    * @param asyncFunction
+    *   to use
+    * @param timeout
+    *   for the asynchronous operation to complete
+    * @param timeUnit
+    *   of the timeout
+    * @param capacity
+    *   of the operator which is equivalent to the number of concurrent asynchronous operations
+    * @param asyncRetryStrategy
+    *   The strategy of reattempt async i/o operation that can be triggered
+    * @tparam IN
+    *   Type of the input record
+    * @tparam OUT
+    *   Type of the output record
+    * @return
+    *   the resulting stream containing the asynchronous results
+    */
+  def orderedWaitWithRetry[IN, OUT: TypeInformation](
+      input: DataStream[IN],
+      asyncFunction: AsyncFunction[IN, OUT],
+      timeout: Long,
+      timeUnit: TimeUnit,
+      capacity: Int,
+      asyncRetryStrategy: JavaAsyncRetryStrategy[OUT]
+  ): DataStream[OUT] = {
+
+    val javaAsyncFunction = wrapAsJavaAsyncFunction(asyncFunction)
+
+    val outType: TypeInformation[OUT] = implicitly[TypeInformation[OUT]]
+
+    asScalaStream(
+      JavaAsyncDataStream
+        .orderedWaitWithRetry[IN, OUT](
+          input.javaStream,
+          javaAsyncFunction,
+          timeout,
+          timeUnit,
+          capacity,
+          asyncRetryStrategy
+        )
+        .returns(outType)
+    )
+  }
+
+  /** Apply an asynchronous function on the input data stream. The output order is the same as the input order of the
+    * elements.
+    *
+    * @param input
+    *   to apply the async function on
+    * @param asyncFunction
+    *   to use
+    * @param timeout
+    *   for the asynchronous operation to complete
+    * @param timeUnit
+    *   of the timeout
+    * @param asyncRetryStrategy
+    *   The strategy of reattempt async i/o operation that can be triggered
+    * @tparam IN
+    *   Type of the input record
+    * @tparam OUT
+    *   Type of the output record
+    * @return
+    *   the resulting stream containing the asynchronous results
+    */
+  def orderedWaitWithRetry[IN, OUT: TypeInformation](
+      input: DataStream[IN],
+      asyncFunction: AsyncFunction[IN, OUT],
+      timeout: Long,
+      timeUnit: TimeUnit,
+      asyncRetryStrategy: JavaAsyncRetryStrategy[OUT]
+  ): DataStream[OUT] = {
+    orderedWaitWithRetry(input, asyncFunction, timeout, timeUnit, DEFAULT_QUEUE_CAPACITY, asyncRetryStrategy)
+  }
+
+  /** Apply an asynchronous function on the input data stream. The output order is the same as the input order of the
+    * elements.
+    *
+    * @param input
+    *   to apply the async function on
+    * @param timeout
+    *   for the asynchronous operation to complete
+    * @param timeUnit
+    *   of the timeout
+    * @param capacity
+    *   of the operator which is equivalent to the number of concurrent asynchronous operations
+    * @param asyncRetryStrategy
+    *   The strategy of reattempt async i/o operation that can be triggered
+    * @param asyncFunction
+    *   to use
+    * @tparam IN
+    *   Type of the input record
+    * @tparam OUT
+    *   Type of the output record
+    * @return
+    *   the resulting stream containing the asynchronous results
+    */
+  def orderedWaitWithRetry[IN, OUT: TypeInformation](
+      input: DataStream[IN],
+      timeout: Long,
+      timeUnit: TimeUnit,
+      capacity: Int,
+      asyncRetryStrategy: JavaAsyncRetryStrategy[OUT]
+  )(
+      asyncFunction: (IN, ResultFuture[OUT]) => Unit
+  ): DataStream[OUT] = {
+
+    Preconditions.checkNotNull(asyncFunction)
+
+    val cleanAsyncFunction = input.executionEnvironment.scalaClean(asyncFunction)
+
+    val func = new JavaAsyncFunction[IN, OUT] {
+      override def asyncInvoke(input: IN, resultFuture: JavaResultFuture[OUT]): Unit = {
+        cleanAsyncFunction(input, new JavaResultFutureWrapper[OUT](resultFuture))
+      }
+    }
+
+    val outType: TypeInformation[OUT] = implicitly[TypeInformation[OUT]]
+
+    asScalaStream(
+      JavaAsyncDataStream
+        .orderedWaitWithRetry[IN, OUT](input.javaStream, func, timeout, timeUnit, capacity, asyncRetryStrategy)
+        .returns(outType)
+    )
+  }
+
+  /** Apply an asynchronous function on the input data stream. The output order is the same as the input order of the
+    * elements.
+    *
+    * @param input
+    *   to apply the async function on
+    * @param timeout
+    *   for the asynchronous operation to complete
+    * @param timeUnit
+    *   of the timeout
+    * @param asyncRetryStrategy
+    *   The strategy of reattempt async i/o operation that can be triggered
+    * @param asyncFunction
+    *   to use
+    * @tparam IN
+    *   Type of the input record
+    * @tparam OUT
+    *   Type of the output record
+    * @return
+    *   the resulting stream containing the asynchronous results
+    */
+  def orderedWaitWithRetry[IN, OUT: TypeInformation](
+      input: DataStream[IN],
+      timeout: Long,
+      timeUnit: TimeUnit,
+      asyncRetryStrategy: JavaAsyncRetryStrategy[OUT]
+  )(
+      asyncFunction: (IN, ResultFuture[OUT]) => Unit
+  ): DataStream[OUT] = {
+
+    orderedWaitWithRetry(input, timeout, timeUnit, DEFAULT_QUEUE_CAPACITY, asyncRetryStrategy)(asyncFunction)
   }
 
   private def wrapAsJavaAsyncFunction[IN, OUT: TypeInformation](

--- a/src/test/scala/org/apache/flinkx/api/AsyncDataStreamTest.scala
+++ b/src/test/scala/org/apache/flinkx/api/AsyncDataStreamTest.scala
@@ -1,0 +1,90 @@
+package org.apache.flinkx.api
+
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.util.retryable.AsyncRetryStrategies
+import org.apache.flinkx.api.async._
+import org.apache.flinkx.api.serializers.intInfo
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterEach}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class AsyncDataStreamTest extends AnyFlatSpec with Matchers with IntegrationTest with BeforeAndAfter {
+  import AsyncDataStreamTest._
+
+  private val source              = env.fromElements(1, 2, 3)
+  private val timeout             = 1000L
+  private val timeUnit            = TimeUnit.MILLISECONDS
+  private val asyncRetryStrategy  = new AsyncRetryStrategies.FixedDelayRetryStrategyBuilder[Int](3, 10).build()
+  private val myRichAsyncFunction = new MyRichAsyncFunction
+  private val anonymousAsyncFunction: (Int, ResultFuture[Int]) => Unit = (input: Int, collector: ResultFuture[Int]) => {
+    Future { collector.complete(Seq(input * 2)) }
+  }
+
+  before {
+    env.setParallelism(1)
+  }
+
+  it should "apply rich async function to the stream in ordered manner" in {
+    AsyncDataStream
+      .orderedWait(source, myRichAsyncFunction, timeout, timeUnit)
+      .collect() should contain theSameElementsInOrderAs List(2, 4, 6)
+  }
+
+  it should "apply rich async function to the stream in ordered manner with retry policy" in {
+    AsyncDataStream
+      .orderedWaitWithRetry(source, myRichAsyncFunction, timeout, timeUnit, asyncRetryStrategy)
+      .collect() should contain theSameElementsInOrderAs List(2, 4, 6)
+  }
+
+  it should "apply rich async function to the stream in unordered manner" in {
+    AsyncDataStream
+      .unorderedWait(source, myRichAsyncFunction, timeout, timeUnit)
+      .collect() should contain theSameElementsAs List(2, 4, 6)
+  }
+
+  it should "apply rich async function to the stream in unordered manner with retry policy" in {
+    AsyncDataStream
+      .orderedWaitWithRetry(source, timeout, timeUnit, asyncRetryStrategy) { anonymousAsyncFunction }
+      .collect() should contain theSameElementsAs List(2, 4, 6)
+  }
+
+  it should "apply anon async function to the stream in ordered manner" in {
+    AsyncDataStream
+      .orderedWait(source, timeout, timeUnit) { anonymousAsyncFunction }
+      .collect() should contain theSameElementsInOrderAs List(2, 4, 6)
+  }
+
+  it should "apply anon async function to the stream in ordered manner with retry policy" in {
+    AsyncDataStream
+      .orderedWaitWithRetry(source, timeout, timeUnit, asyncRetryStrategy) { anonymousAsyncFunction }
+      .collect() should contain theSameElementsInOrderAs List(2, 4, 6)
+  }
+
+  it should "apply anon async function to the stream in unordered manner" in {
+    AsyncDataStream
+      .unorderedWait(source, timeout, timeUnit) { anonymousAsyncFunction }
+      .collect() should contain theSameElementsAs List(2, 4, 6)
+  }
+
+  it should "apply anon async function to the stream in unordered manner with retry policy" in {
+    AsyncDataStream
+      .orderedWaitWithRetry(source, timeout, timeUnit, asyncRetryStrategy) { anonymousAsyncFunction }
+      .collect() should contain theSameElementsAs List(2, 4, 6)
+  }
+}
+
+object AsyncDataStreamTest {
+  class MyRichAsyncFunction extends RichAsyncFunction[Int, Int] {
+    override def open(parameters: Configuration): Unit = {
+      assert(getRuntimeContext.getNumberOfParallelSubtasks == 1)
+    }
+
+    override def asyncInvoke(input: Int, resultFuture: ResultFuture[Int]): Unit = Future {
+      resultFuture.complete(Seq(input * 2))
+    }
+  }
+}


### PR DESCRIPTION
Addresses https://github.com/flink-extended/flink-scala-api/issues/99 and requires https://github.com/flink-extended/flink-scala-api/pull/100 to be merged first to deprecate 1.15 support in CI, release builds.

This change adds `WithRetry` versions to the currently existing async stream helpers, it uses the already-built official retry strategy interface, which will allow to use of already pre-built retry strategies.

~~I see that the async wrapper had no test strategies, do we need one? Official client is covered https://github.com/apache/flink/blob/master/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/AsyncDataStreamITCase.scala~~

I've used specs from original flink scala library as a source and adapted the implementation.