### PR TITLE
Fix case class serializer snapshot compatibility

### DIFF
--- a/src/main/java/org/apache/flink/api/serializer/ScalaCaseClassSerializerSnapshot.java
+++ b/src/main/java/org/apache/flink/api/serializer/ScalaCaseClassSerializerSnapshot.java
@@ -28,6 +28,7 @@ import org.apache.flink.util.InstantiationUtil;
 
 import java.io.IOException;
 import java.util.Objects;
+import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -87,7 +88,9 @@ public final class ScalaCaseClassSerializerSnapshot<T extends scala.Product>
     @Override
     protected CompositeTypeSerializerSnapshot.OuterSchemaCompatibility
     resolveOuterSchemaCompatibility(ScalaCaseClassSerializer<T> newSerializer) {
-        if (Objects.equals(type, newSerializer.getTupleClass())) {
+        var currentTypeName = Optional.ofNullable(type).map(Class::getName);
+        var newTypeName = Optional.ofNullable(newSerializer.getTupleClass()).map(Class::getName);
+        if (currentTypeName.equals(newTypeName)) {
             return OuterSchemaCompatibility.COMPATIBLE_AS_IS;
         } else {
             return OuterSchemaCompatibility.INCOMPATIBLE;

--- a/src/test/scala/org/apache/flinkx/api/SerializerSnapshotTest.scala
+++ b/src/test/scala/org/apache/flinkx/api/SerializerSnapshotTest.scala
@@ -17,67 +17,89 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.apache.flinkx.api.serializers._
 import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.util.ChildFirstClassLoader
 import org.scalatest.Assertion
+
+import java.net.URLClassLoader
 
 class SerializerSnapshotTest extends AnyFlatSpec with Matchers {
 
   it should "roundtrip product serializer snapshot" in {
     val ser = deriveTypeInformation[SimpleClass1].createSerializer(null)
-    roundtripSerializer(ser)
+    assertRoundtripSerializer(ser)
   }
 
   it should "roundtrip coproduct serializer snapshot" in {
     val ser = deriveTypeInformation[OuterTrait].createSerializer(null)
-    roundtripSerializer(ser)
+    assertRoundtripSerializer(ser)
   }
 
   it should "roundtrip coproduct serializer snapshot with singletons" in {
     val ser = deriveTypeInformation[ADT2].createSerializer(null)
-    roundtripSerializer(ser)
+    assertRoundtripSerializer(ser)
   }
 
   it should "roundtrip serializer snapshot with list of primitives" in {
     val ser = deriveTypeInformation[List[Double]].createSerializer(null)
-    roundtripSerializer(ser)
+    assertRoundtripSerializer(ser)
   }
 
   it should "roundtrip serializer snapshot with set as array of primitives" in {
     val ser = implicitly[TypeInformation[Set[Double]]].createSerializer(null)
-    roundtripSerializer(ser)
+    assertRoundtripSerializer(ser)
   }
 
   it should "do array ser snapshot" in {
     val set = deriveTypeInformation[SimpleClassArray].createSerializer(null)
-    roundtripSerializer(set)
+    assertRoundtripSerializer(set)
   }
 
   it should "do map ser snapshot" in {
-    roundtripSerializer(deriveTypeInformation[SimpleClassMap1].createSerializer(null))
-    roundtripSerializer(deriveTypeInformation[SimpleClassMap2].createSerializer(null))
+    assertRoundtripSerializer(deriveTypeInformation[SimpleClassMap1].createSerializer(null))
+    assertRoundtripSerializer(deriveTypeInformation[SimpleClassMap2].createSerializer(null))
   }
 
   it should "do list ser snapshot" in {
-    roundtripSerializer(deriveTypeInformation[SimpleClassList].createSerializer(null))
+    assertRoundtripSerializer(deriveTypeInformation[SimpleClassList].createSerializer(null))
   }
 
   it should "do map ser snapshot adt " in {
     implicit val ti: Typeclass[OuterTrait] = deriveTypeInformation[OuterTrait]
     drop(ti)
-    roundtripSerializer(deriveTypeInformation[TraitMap].createSerializer(null))
+    assertRoundtripSerializer(deriveTypeInformation[TraitMap].createSerializer(null))
   }
 
-  it should ""
+  it should "be compatible after snapshot deserialization in different classloader" in {
+    val ser = deriveTypeInformation[SimpleClass1].createSerializer(null)
+    val cl = newClassLoader(classOf[SimpleClass1])
+    try {
+      val restored = roundtripSerializer(ser, cl)
+      val compatibility = restored.snapshotConfiguration().resolveSchemaCompatibility(ser)
+      compatibility shouldBe Symbol("compatibleAsIs")
+    } finally {
+      cl.close()
+    }
+  }
 
-  def roundtripSerializer[T](ser: TypeSerializer[T]): Assertion = {
-    val snap   = ser.snapshotConfiguration()
+  def roundtripSerializer[T](ser: TypeSerializer[T], cl: ClassLoader = getClass.getClassLoader): TypeSerializer[T] = {
+    val snap = ser.snapshotConfiguration()
     val buffer = new ByteArrayOutputStream()
     val output = new DataOutputViewStreamWrapper(buffer)
     snap.writeSnapshot(output)
     output.close()
     val input = new DataInputViewStreamWrapper(new ByteArrayInputStream(buffer.toByteArray))
-    snap.readSnapshot(ser.snapshotConfiguration().getCurrentVersion, input, getClass.getClassLoader)
-    val restored = snap.restoreSerializer()
+    snap.readSnapshot(ser.snapshotConfiguration().getCurrentVersion, input, cl)
+    snap.restoreSerializer()
+  }
+
+  def assertRoundtripSerializer[T](ser: TypeSerializer[T]): Assertion = {
+    val restored = roundtripSerializer(ser)
     ser shouldBe restored
+  }
+
+  def newClassLoader(cls: Class[_]): URLClassLoader = {
+    val urls = Array(cls.getProtectionDomain.getCodeSource.getLocation)
+    new ChildFirstClassLoader(urls, cls.getClassLoader, Array(), _ => {})
   }
 
 }


### PR DESCRIPTION
In Flink session-mode clusters, `resolveSchemaCompatibility` returns `INCOMPATIBLE` even for identical case classes (even without any recompiles or reuploads to the cluster). This is due to way Flink state restore works, resulting in the same class being loaded multiple times in different classloaders.

Steps to reproduce:
1. Start Flink cluster in session-mode.
2. Start some job with single operator that saves case class in the state.
3. Wait for the checkpoint.
4. Kill the job.
5. Restart the job from the checkpoint - Flink fails to init the operator with the case class in the state.

To mitigate the issue, I've changed the outer check from direct class equality, which in reality is just reference equality, to class name comparison.