### PR TITLE
Revert "Update scala3-compiler, scala3-library to 3.4.1"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     strategy:
       matrix:
         java: [11]
-        scala: [2.12.19, 2.13.13, 3.4.1]
+        scala: [2.12.19, 2.13.13, 3.3.3]
         flink: [1.16.3, 1.17.2]
         include:
-          - scala: 3.4.1
+          - scala: 3.3.3
             java: 17
             flink: 1.18.1
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import ReleaseProcess._
 Global / onChangedBuildSource := ReloadOnSourceChanges
 Global / excludeLintKeys      := Set(git.useGitDescribe)
 
-lazy val rootScalaVersion = "3.4.1"
+lazy val rootScalaVersion = "3.3.3"
 lazy val flinkVersion     = System.getProperty("flinkVersion", "1.16.3")
 
 lazy val root = (project in file("."))


### PR DESCRIPTION
Reverts flink-extended/flink-scala-api#103

Keeping LTS version of Scala 3.3.x rather than go for 3.4.
See more here: https://www.scala-lang.org/blog/2024/02/29/scala-3.4.0-and-3.3.3-released.html