### PR TITLE
Fix concurrency bug in subclasses of TypeInformation

### DIFF
--- a/src/main/scala/org/apache/flinkx/api/serializer/CaseClassSerializer.scala
+++ b/src/main/scala/org/apache/flinkx/api/serializer/CaseClassSerializer.scala
@@ -39,6 +39,8 @@ abstract class CaseClassSerializer[T <: Product](
 
   @transient lazy val log: Logger = LoggerFactory.getLogger(this.getClass)
 
+  override def isImmutableType(): Boolean = true
+  
   override def duplicate: CaseClassSerializer[T] = {
     clone().asInstanceOf[CaseClassSerializer[T]]
   }

--- a/src/main/scala/org/apache/flinkx/api/typeinfo/CollectionTypeInformation.scala
+++ b/src/main/scala/org/apache/flinkx/api/typeinfo/CollectionTypeInformation.scala
@@ -8,11 +8,13 @@ import scala.reflect.{ClassTag, classTag}
 
 case class CollectionTypeInformation[T: ClassTag](serializer: TypeSerializer[T]) extends TypeInformation[T] {
   val clazz = classTag[T].runtimeClass.asInstanceOf[Class[T]]
-  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = serializer
-  override def isBasicType: Boolean                                         = false
-  override def isTupleType: Boolean                                         = false
-  override def isKeyType: Boolean                                           = false
-  override def getTotalFields: Int                                          = 1
-  override def getTypeClass: Class[T]                                       = clazz
-  override def getArity: Int                                                = 1
+  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] =
+    if (serializer.isImmutableType) serializer
+    else serializer.duplicate()
+  override def isBasicType: Boolean   = false
+  override def isTupleType: Boolean   = false
+  override def isKeyType: Boolean     = false
+  override def getTotalFields: Int    = 1
+  override def getTypeClass: Class[T] = clazz
+  override def getArity: Int          = 1
 }

--- a/src/main/scala/org/apache/flinkx/api/typeinfo/CollectionTypeInformation.scala
+++ b/src/main/scala/org/apache/flinkx/api/typeinfo/CollectionTypeInformation.scala
@@ -8,7 +8,7 @@ import scala.reflect.{ClassTag, classTag}
 
 case class CollectionTypeInformation[T: ClassTag](serializer: TypeSerializer[T]) extends TypeInformation[T] {
   val clazz = classTag[T].runtimeClass.asInstanceOf[Class[T]]
-  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = serializer.duplicate()
+  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = serializer
   override def isBasicType: Boolean                                         = false
   override def isTupleType: Boolean                                         = false
   override def isKeyType: Boolean                                           = false

--- a/src/main/scala/org/apache/flinkx/api/typeinfo/CollectionTypeInformation.scala
+++ b/src/main/scala/org/apache/flinkx/api/typeinfo/CollectionTypeInformation.scala
@@ -8,7 +8,7 @@ import scala.reflect.{ClassTag, classTag}
 
 case class CollectionTypeInformation[T: ClassTag](serializer: TypeSerializer[T]) extends TypeInformation[T] {
   val clazz = classTag[T].runtimeClass.asInstanceOf[Class[T]]
-  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = serializer
+  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = serializer.duplicate()
   override def isBasicType: Boolean                                         = false
   override def isTupleType: Boolean                                         = false
   override def isKeyType: Boolean                                           = false

--- a/src/main/scala/org/apache/flinkx/api/typeinfo/CoproductTypeInformation.scala
+++ b/src/main/scala/org/apache/flinkx/api/typeinfo/CoproductTypeInformation.scala
@@ -5,7 +5,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.TypeSerializer
 
 case class CoproductTypeInformation[T](c: Class[T], ser: TypeSerializer[T]) extends TypeInformation[T] {
-  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = ser.duplicate()
+  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = ser
   override def isBasicType: Boolean                                         = false
   override def isTupleType: Boolean                                         = false
   override def isKeyType: Boolean                                           = false

--- a/src/main/scala/org/apache/flinkx/api/typeinfo/CoproductTypeInformation.scala
+++ b/src/main/scala/org/apache/flinkx/api/typeinfo/CoproductTypeInformation.scala
@@ -5,7 +5,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.TypeSerializer
 
 case class CoproductTypeInformation[T](c: Class[T], ser: TypeSerializer[T]) extends TypeInformation[T] {
-  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = ser
+  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = ser.duplicate()
   override def isBasicType: Boolean                                         = false
   override def isTupleType: Boolean                                         = false
   override def isKeyType: Boolean                                           = false

--- a/src/main/scala/org/apache/flinkx/api/typeinfo/ProductTypeInformation.scala
+++ b/src/main/scala/org/apache/flinkx/api/typeinfo/ProductTypeInformation.scala
@@ -15,5 +15,5 @@ class ProductTypeInformation[T <: Product](
       fieldTypes,
       fieldNames
     ) {
-  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = ser
+  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = ser.duplicate()
 }

--- a/src/main/scala/org/apache/flinkx/api/typeinfo/ProductTypeInformation.scala
+++ b/src/main/scala/org/apache/flinkx/api/typeinfo/ProductTypeInformation.scala
@@ -15,5 +15,5 @@ class ProductTypeInformation[T <: Product](
       fieldTypes,
       fieldNames
     ) {
-  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = ser.duplicate()
+  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = ser
 }

--- a/src/main/scala/org/apache/flinkx/api/typeinfo/ProductTypeInformation.scala
+++ b/src/main/scala/org/apache/flinkx/api/typeinfo/ProductTypeInformation.scala
@@ -15,5 +15,7 @@ class ProductTypeInformation[T <: Product](
       fieldTypes,
       fieldNames
     ) {
-  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = ser
+  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] =
+    if (ser.isImmutableType) ser
+    else ser.duplicate()
 }

--- a/src/main/scala/org/apache/flinkx/api/typeinfo/SimpleTypeInformation.scala
+++ b/src/main/scala/org/apache/flinkx/api/typeinfo/SimpleTypeInformation.scala
@@ -7,7 +7,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer
 import scala.reflect.{classTag, ClassTag}
 
 abstract class SimpleTypeInformation[T: ClassTag: TypeSerializer] extends TypeInformation[T] {
-  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = implicitly[TypeSerializer[T]]
+  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = implicitly[TypeSerializer[T]].duplicate()
   override def isBasicType: Boolean                                         = false
   override def isTupleType: Boolean                                         = false
   override def isKeyType: Boolean                                           = false

--- a/src/main/scala/org/apache/flinkx/api/typeinfo/SimpleTypeInformation.scala
+++ b/src/main/scala/org/apache/flinkx/api/typeinfo/SimpleTypeInformation.scala
@@ -7,7 +7,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer
 import scala.reflect.{classTag, ClassTag}
 
 abstract class SimpleTypeInformation[T: ClassTag: TypeSerializer] extends TypeInformation[T] {
-  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = implicitly[TypeSerializer[T]].duplicate()
+  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = implicitly[TypeSerializer[T]]
   override def isBasicType: Boolean                                         = false
   override def isTupleType: Boolean                                         = false
   override def isKeyType: Boolean                                           = false

--- a/src/main/scala/org/apache/flinkx/api/typeinfo/SimpleTypeInformation.scala
+++ b/src/main/scala/org/apache/flinkx/api/typeinfo/SimpleTypeInformation.scala
@@ -7,11 +7,15 @@ import org.apache.flink.api.common.typeutils.TypeSerializer
 import scala.reflect.{classTag, ClassTag}
 
 abstract class SimpleTypeInformation[T: ClassTag: TypeSerializer] extends TypeInformation[T] {
-  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = implicitly[TypeSerializer[T]]
-  override def isBasicType: Boolean                                         = false
-  override def isTupleType: Boolean                                         = false
-  override def isKeyType: Boolean                                           = false
-  override def getTotalFields: Int                                          = 1
+  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = {
+    val ser = implicitly[TypeSerializer[T]]
+    if (ser.isImmutableType) ser
+    else ser.duplicate()
+  }
+  override def isBasicType: Boolean   = false
+  override def isTupleType: Boolean   = false
+  override def isKeyType: Boolean     = false
+  override def getTotalFields: Int    = 1
   override def getTypeClass: Class[T] = classTag[T].runtimeClass.asInstanceOf[Class[T]]
   override def getArity: Int          = 1
 }


### PR DESCRIPTION
Fixes #111 

I made sure that all subclasses of `TypeInformation` in this repository creates a new instance of `TypeSerializer` when `.createSerializer()` method is called.

Besides, while working on it I found that the most of the `TypeSerializer`s in this repository have incorrect method implementations (duplicate, copy, isImmutableType, etc.) They could lead to undesirable behaviors when utilized by Flink. I'll try to fix them when I have some time to do it.

