### PR TITLE
Call duplicate when type is not immutable

### DIFF
--- a/src/main/scala/org/apache/flinkx/api/serializer/CaseClassSerializer.scala
+++ b/src/main/scala/org/apache/flinkx/api/serializer/CaseClassSerializer.scala
@@ -39,9 +39,11 @@ abstract class CaseClassSerializer[T <: Product](
 
   @transient lazy val log: Logger = LoggerFactory.getLogger(this.getClass)
 
-  override def duplicate: CaseClassSerializer[T] = {
+  override def isImmutableType: Boolean =
+    scalaFieldSerializers.forall(_.isImmutableType)
+
+  override def duplicate: CaseClassSerializer[T] =
     clone().asInstanceOf[CaseClassSerializer[T]]
-  }
 
   @throws[CloneNotSupportedException]
   override protected def clone(): Object = {

--- a/src/main/scala/org/apache/flinkx/api/typeinfo/CollectionTypeInformation.scala
+++ b/src/main/scala/org/apache/flinkx/api/typeinfo/CollectionTypeInformation.scala
@@ -8,11 +8,13 @@ import scala.reflect.{ClassTag, classTag}
 
 case class CollectionTypeInformation[T: ClassTag](serializer: TypeSerializer[T]) extends TypeInformation[T] {
   val clazz = classTag[T].runtimeClass.asInstanceOf[Class[T]]
-  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = serializer
-  override def isBasicType: Boolean                                         = false
-  override def isTupleType: Boolean                                         = false
-  override def isKeyType: Boolean                                           = false
-  override def getTotalFields: Int                                          = 1
-  override def getTypeClass: Class[T]                                       = clazz
-  override def getArity: Int                                                = 1
+  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] =
+    if (serializer.isImmutableType) serializer
+    else serializer.duplicate()
+  override def isBasicType: Boolean   = false
+  override def isTupleType: Boolean   = false
+  override def isKeyType: Boolean     = false
+  override def getTotalFields: Int    = 1
+  override def getTypeClass: Class[T] = clazz
+  override def getArity: Int          = 1
 }

--- a/src/main/scala/org/apache/flinkx/api/typeinfo/CollectionTypeInformation.scala
+++ b/src/main/scala/org/apache/flinkx/api/typeinfo/CollectionTypeInformation.scala
@@ -8,7 +8,7 @@ import scala.reflect.{ClassTag, classTag}
 
 case class CollectionTypeInformation[T: ClassTag](serializer: TypeSerializer[T]) extends TypeInformation[T] {
   val clazz = classTag[T].runtimeClass.asInstanceOf[Class[T]]
-  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = serializer.duplicate()
+  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = serializer
   override def isBasicType: Boolean                                         = false
   override def isTupleType: Boolean                                         = false
   override def isKeyType: Boolean                                           = false

--- a/src/main/scala/org/apache/flinkx/api/typeinfo/CollectionTypeInformation.scala
+++ b/src/main/scala/org/apache/flinkx/api/typeinfo/CollectionTypeInformation.scala
@@ -8,7 +8,7 @@ import scala.reflect.{ClassTag, classTag}
 
 case class CollectionTypeInformation[T: ClassTag](serializer: TypeSerializer[T]) extends TypeInformation[T] {
   val clazz = classTag[T].runtimeClass.asInstanceOf[Class[T]]
-  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = serializer
+  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = serializer.duplicate()
   override def isBasicType: Boolean                                         = false
   override def isTupleType: Boolean                                         = false
   override def isKeyType: Boolean                                           = false

--- a/src/main/scala/org/apache/flinkx/api/typeinfo/CoproductTypeInformation.scala
+++ b/src/main/scala/org/apache/flinkx/api/typeinfo/CoproductTypeInformation.scala
@@ -5,7 +5,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.TypeSerializer
 
 case class CoproductTypeInformation[T](c: Class[T], ser: TypeSerializer[T]) extends TypeInformation[T] {
-  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = ser.duplicate()
+  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = ser
   override def isBasicType: Boolean                                         = false
   override def isTupleType: Boolean                                         = false
   override def isKeyType: Boolean                                           = false

--- a/src/main/scala/org/apache/flinkx/api/typeinfo/CoproductTypeInformation.scala
+++ b/src/main/scala/org/apache/flinkx/api/typeinfo/CoproductTypeInformation.scala
@@ -5,11 +5,13 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.TypeSerializer
 
 case class CoproductTypeInformation[T](c: Class[T], ser: TypeSerializer[T]) extends TypeInformation[T] {
-  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = ser.duplicate()
-  override def isBasicType: Boolean                                         = false
-  override def isTupleType: Boolean                                         = false
-  override def isKeyType: Boolean                                           = false
-  override def getTotalFields: Int                                          = 1
-  override def getTypeClass: Class[T]                                       = c
-  override def getArity: Int                                                = 1
+  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] =
+    if (ser.isImmutableType) ser
+    else ser.duplicate()
+  override def isBasicType: Boolean   = false
+  override def isTupleType: Boolean   = false
+  override def isKeyType: Boolean     = false
+  override def getTotalFields: Int    = 1
+  override def getTypeClass: Class[T] = c
+  override def getArity: Int          = 1
 }

--- a/src/main/scala/org/apache/flinkx/api/typeinfo/CoproductTypeInformation.scala
+++ b/src/main/scala/org/apache/flinkx/api/typeinfo/CoproductTypeInformation.scala
@@ -5,7 +5,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.TypeSerializer
 
 case class CoproductTypeInformation[T](c: Class[T], ser: TypeSerializer[T]) extends TypeInformation[T] {
-  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = ser
+  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = ser.duplicate()
   override def isBasicType: Boolean                                         = false
   override def isTupleType: Boolean                                         = false
   override def isKeyType: Boolean                                           = false

--- a/src/main/scala/org/apache/flinkx/api/typeinfo/ProductTypeInformation.scala
+++ b/src/main/scala/org/apache/flinkx/api/typeinfo/ProductTypeInformation.scala
@@ -15,5 +15,5 @@ class ProductTypeInformation[T <: Product](
       fieldTypes,
       fieldNames
     ) {
-  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = ser
+  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = ser.duplicate()
 }

--- a/src/main/scala/org/apache/flinkx/api/typeinfo/ProductTypeInformation.scala
+++ b/src/main/scala/org/apache/flinkx/api/typeinfo/ProductTypeInformation.scala
@@ -15,5 +15,5 @@ class ProductTypeInformation[T <: Product](
       fieldTypes,
       fieldNames
     ) {
-  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = ser.duplicate()
+  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = ser
 }

--- a/src/main/scala/org/apache/flinkx/api/typeinfo/ProductTypeInformation.scala
+++ b/src/main/scala/org/apache/flinkx/api/typeinfo/ProductTypeInformation.scala
@@ -15,5 +15,7 @@ class ProductTypeInformation[T <: Product](
       fieldTypes,
       fieldNames
     ) {
-  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = ser
+  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] =
+    if (ser.isImmutableType) ser
+    else ser.duplicate()
 }

--- a/src/main/scala/org/apache/flinkx/api/typeinfo/SimpleTypeInformation.scala
+++ b/src/main/scala/org/apache/flinkx/api/typeinfo/SimpleTypeInformation.scala
@@ -7,7 +7,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer
 import scala.reflect.{classTag, ClassTag}
 
 abstract class SimpleTypeInformation[T: ClassTag: TypeSerializer] extends TypeInformation[T] {
-  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = implicitly[TypeSerializer[T]]
+  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = implicitly[TypeSerializer[T]].duplicate()
   override def isBasicType: Boolean                                         = false
   override def isTupleType: Boolean                                         = false
   override def isKeyType: Boolean                                           = false

--- a/src/main/scala/org/apache/flinkx/api/typeinfo/SimpleTypeInformation.scala
+++ b/src/main/scala/org/apache/flinkx/api/typeinfo/SimpleTypeInformation.scala
@@ -7,7 +7,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer
 import scala.reflect.{classTag, ClassTag}
 
 abstract class SimpleTypeInformation[T: ClassTag: TypeSerializer] extends TypeInformation[T] {
-  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = implicitly[TypeSerializer[T]].duplicate()
+  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = implicitly[TypeSerializer[T]]
   override def isBasicType: Boolean                                         = false
   override def isTupleType: Boolean                                         = false
   override def isKeyType: Boolean                                           = false

--- a/src/main/scala/org/apache/flinkx/api/typeinfo/SimpleTypeInformation.scala
+++ b/src/main/scala/org/apache/flinkx/api/typeinfo/SimpleTypeInformation.scala
@@ -7,11 +7,15 @@ import org.apache.flink.api.common.typeutils.TypeSerializer
 import scala.reflect.{classTag, ClassTag}
 
 abstract class SimpleTypeInformation[T: ClassTag: TypeSerializer] extends TypeInformation[T] {
-  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = implicitly[TypeSerializer[T]]
-  override def isBasicType: Boolean                                         = false
-  override def isTupleType: Boolean                                         = false
-  override def isKeyType: Boolean                                           = false
-  override def getTotalFields: Int                                          = 1
+  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = {
+    val ser = implicitly[TypeSerializer[T]]
+    if (ser.isImmutableType) ser
+    else ser.duplicate()
+  }
+  override def isBasicType: Boolean   = false
+  override def isTupleType: Boolean   = false
+  override def isKeyType: Boolean     = false
+  override def getTotalFields: Int    = 1
   override def getTypeClass: Class[T] = classTag[T].runtimeClass.asInstanceOf[Class[T]]
   override def getArity: Int          = 1
 }

--- a/src/test/scala/org/apache/flinkx/api/SerializerTest.scala
+++ b/src/test/scala/org/apache/flinkx/api/SerializerTest.scala
@@ -136,6 +136,13 @@ class SerializerTest extends AnyFlatSpec with Matchers with Inspectors with Test
 //    noKryo(ser)
 //  }
 
+  it should "instantiate a new TypeSerializer instance with case classes" in {
+    val ti = implicitly[TypeInformation[Simple]]
+    val ser1 = ti.createSerializer(null)
+    val ser2 = ti.createSerializer(null)
+    ser1 shouldNot be theSameInstanceAs ser2
+  }
+
   it should "be serializable in case of annotations on classes" in {
     val ser = implicitly[TypeInformation[Annotated]].createSerializer(null)
     serializable(ser)

--- a/src/test/scala/org/apache/flinkx/api/SerializerTest.scala
+++ b/src/test/scala/org/apache/flinkx/api/SerializerTest.scala
@@ -136,11 +136,11 @@ class SerializerTest extends AnyFlatSpec with Matchers with Inspectors with Test
 //    noKryo(ser)
 //  }
 
-  it should "instantiate a new TypeSerializer instance with case classes" in {
+  it should "return the same TypeSerializer instance with case classes" in {
     val ti = implicitly[TypeInformation[Simple]]
     val ser1 = ti.createSerializer(null)
     val ser2 = ti.createSerializer(null)
-    ser1 shouldNot be theSameInstanceAs ser2
+    ser1 should be theSameInstanceAs ser2
   }
 
   it should "be serializable in case of annotations on classes" in {


### PR DESCRIPTION
Additional change for some of the TypeInfos to call duplicate serializers when they are not immutable.

FYI @sonowz 