### PR TITLE
fix: Do not evaluate isClassArityUsageDisabled on every serialize/des…

### DIFF
--- a/modules/scala-api/src/main/scala/org/apache/flinkx/api/serializer/CaseClassSerializer.scala
+++ b/modules/scala-api/src/main/scala/org/apache/flinkx/api/serializer/CaseClassSerializer.scala
@@ -39,6 +39,14 @@ abstract class CaseClassSerializer[T <: Product](
 
   @transient lazy val log: Logger = LoggerFactory.getLogger(this.getClass)
 
+  @transient private val isClassArityUsageDisabled =
+    sys.env
+      .get("DISABLE_CASE_CLASS_ARITY_USAGE")
+      .exists(v =>
+        Try(v.toBoolean)
+          .getOrElse(false)
+      )
+
   override def isImmutableType: Boolean =
     scalaFieldSerializers.forall(s => Option(s).exists(_.isImmutableType))
 
@@ -77,13 +85,6 @@ abstract class CaseClassSerializer[T <: Product](
       createInstance(fields.toArray)
     }
 
-  private def isClassArityUsageDisabled =
-    sys.env
-      .get("DISABLE_CASE_CLASS_ARITY_USAGE")
-      .exists(v =>
-        Try(v.toBoolean)
-          .getOrElse(false)
-      )
 
   def serialize(value: T, target: DataOutputView): Unit = {
     if (arity > 0 && !isClassArityUsageDisabled)


### PR DESCRIPTION
…erialize function call

I noticed degraded performance after upgrading to new version. 
`isClassArityUsageDisabled` was evaluated on every serialize/deserialize function call.
This is quite expensive because list is created every time, then `get` and `exist` iterates via list.
This can be observed in attached flamegraph:


![image](https://github.com/user-attachments/assets/66fa4c71-324d-4c2d-849d-ce7bc38140fe)
