### PR TITLE
#187 Documents state migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,19 @@ import org.apache.flinkx.api.serializers._
 
 ### State
 
-Ensure to replace state descriptor constructors using `Class[T]` param with constructors using `TypeInformation[T]` or  `TypeSerializer[T]` param:
-```scala
+Ensure to replace state descriptor constructors using `Class[T]` param with constructors using `TypeInformation[T]` or `TypeSerializer[T]` param:
+```scala mdoc
+import org.apache.flink.api.common.state.ValueStateDescriptor
+import org.apache.flink.api.common.typeinfo.TypeInformation
 // state using Kryo
-val eventStateDescriptor = new ValueStateDescriptor[Event]("event", classOf[Event])
+val eventStateDescriptor = new ValueStateDescriptor[Option[String]]("event", classOf[Option[String]])
 ```
-```scala
+```scala mdoc:reset-object
+import org.apache.flinkx.api.serializers._
+import org.apache.flink.api.common.state.ValueStateDescriptor
+import org.apache.flink.api.common.typeinfo.TypeInformation
 // state using flink-scala-api
-val eventStateDescriptor = new ValueStateDescriptor[Event]("event", implicitly[TypeInformation[Event]])
+val eventStateDescriptor = new ValueStateDescriptor[Option[String]]("event", implicitly[TypeInformation[Option[String]]])
 ```
 
 ## Usage 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This project is a community-maintained fork of official Apache Flink Scala API, 
 `flink-scala-api` uses a different package name for all api-related classes like `DataStream`, so you can do
 gradual migration of a big project and use both upstream and this versions of scala API in the same project. 
 
+### API
+
 The actual migration should be straightforward and simple, replace old import to the new ones:
 ```scala
 // original api import
@@ -22,6 +24,18 @@ import org.apache.flink.streaming.api.scala._
 // flink-scala-api imports
 import org.apache.flinkx.api._
 import org.apache.flinkx.api.serializers._
+```
+
+### State
+
+`flink-scala-api` generates at compile-time specific TypeInformation & TypeSerializer. To use them for state serialization, ensure to replace state descriptor constructors using `Class[T]` param with constructors using `TypeInformation[T]` param:
+```scala
+// state using Kryo
+val eventStateDescriptor = new ValueStateDescriptor[Event]("event", classOf[Event])
+```
+```scala
+// state using flink-scala-api
+val eventStateDescriptor = new ValueStateDescriptor[Event]("event", implicitly[TypeInformation[Event]])
 ```
 
 ## Usage 

--- a/README.md
+++ b/README.md
@@ -32,15 +32,19 @@ Ensure to replace state descriptor constructors using `Class[T]` param with cons
 ```scala mdoc
 import org.apache.flink.api.common.state.ValueStateDescriptor
 import org.apache.flink.api.common.typeinfo.TypeInformation
+
 // state using Kryo
-val eventStateDescriptor = new ValueStateDescriptor[Option[String]]("event", classOf[Option[String]])
+val eventStateDescriptor = new ValueStateDescriptor[Option[String]]("event",
+  classOf[Option[String]])
 ```
 ```scala mdoc:reset-object
 import org.apache.flinkx.api.serializers._
 import org.apache.flink.api.common.state.ValueStateDescriptor
 import org.apache.flink.api.common.typeinfo.TypeInformation
+
 // state using flink-scala-api
-val eventStateDescriptor = new ValueStateDescriptor[Option[String]]("event", implicitly[TypeInformation[Option[String]]])
+val eventStateDescriptor = new ValueStateDescriptor[Option[String]]("event",
+  implicitly[TypeInformation[Option[String]]])
 ```
 
 ## Usage 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ import org.apache.flinkx.api.serializers._
 
 ### State
 
-`flink-scala-api` generates at compile-time specific TypeInformation & TypeSerializer. To use them for state serialization, ensure to replace state descriptor constructors using `Class[T]` param with constructors using `TypeInformation[T]` param:
+Ensure to replace state descriptor constructors using `Class[T]` param with constructors using `TypeInformation[T]` or  `TypeSerializer[T]` param:
 ```scala
 // state using Kryo
 val eventStateDescriptor = new ValueStateDescriptor[Event]("event", classOf[Event])


### PR DESCRIPTION
A proposal to add a `State` section under `Migration` of the readme to warn about risk of state descriptor misuse described in issue #187.