### PR TITLE
add implicit converters to Java counterparts

### DIFF
--- a/modules/scala-api/src/main/scala/org/apache/flinkx/api/conv.scala
+++ b/modules/scala-api/src/main/scala/org/apache/flinkx/api/conv.scala
@@ -1,0 +1,12 @@
+package org.apache.flinkx.api
+
+import org.apache.flink.streaming.api.environment.{StreamExecutionEnvironment => JavaEnv}
+import org.apache.flink.streaming.api.datastream.{DataStream => JavaStream}
+
+import scala.language.implicitConversions
+
+object conv {
+  implicit def toJavaEnv(e: StreamExecutionEnvironment): JavaEnv = e.getJavaEnv
+  
+  implicit def toJavaDataStream[T](d: DataStream[T]): JavaStream[T] = d.javaStream
+}


### PR DESCRIPTION
Allows to pass Scala API wrappers as Java types