### PR TITLE
#206 Reproduce derivation of generic case class issue & fix for Scala 2

### DIFF
--- a/modules/scala-api/src/main/scala-2/org/apache/flinkx/api/LowPrioImplicits.scala
+++ b/modules/scala-api/src/main/scala-2/org/apache/flinkx/api/LowPrioImplicits.scala
@@ -1,10 +1,10 @@
 package org.apache.flinkx.api
 
-import org.apache.flinkx.api.serializer.{CoproductSerializer, ScalaCaseClassSerializer, ScalaCaseObjectSerializer}
-import org.apache.flinkx.api.typeinfo.{CoproductTypeInformation, ProductTypeInformation}
 import magnolia1.{CaseClass, Magnolia, SealedTrait}
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flinkx.api.serializer.{CoproductSerializer, ScalaCaseClassSerializer, ScalaCaseObjectSerializer}
+import org.apache.flinkx.api.typeinfo.{CoproductTypeInformation, ProductTypeInformation}
 
 import scala.collection.mutable
 import scala.language.experimental.macros
@@ -21,7 +21,7 @@ private[api] trait LowPrioImplicits {
   def join[T <: Product: ClassTag: TypeTag](
       ctx: CaseClass[TypeInformation, T]
   ): TypeInformation[T] = {
-    val cacheKey = typeName(ctx.typeName)
+    val cacheKey = typeName[T]
     cache.get(cacheKey) match {
       case Some(cached) => cached.asInstanceOf[TypeInformation[T]]
       case None =>
@@ -45,8 +45,8 @@ private[api] trait LowPrioImplicits {
     }
   }
 
-  def split[T: ClassTag](ctx: SealedTrait[TypeInformation, T]): TypeInformation[T] = {
-    val cacheKey = typeName(ctx.typeName)
+  def split[T: ClassTag : TypeTag](ctx: SealedTrait[TypeInformation, T]): TypeInformation[T] = {
+    val cacheKey = typeName[T]
     cache.get(cacheKey) match {
       case Some(cached) => cached.asInstanceOf[TypeInformation[T]]
       case None =>
@@ -61,8 +61,7 @@ private[api] trait LowPrioImplicits {
     }
   }
 
-  private def typeName(tn: magnolia1.TypeName): String =
-    s"${tn.full}[${tn.typeArguments.map(typeName).mkString(",")}]"
+  private def typeName[T: TypeTag]: String = typeOf[T].toString
 
   implicit def deriveTypeInformation[T]: TypeInformation[T] = macro Magnolia.gen[T]
 }

--- a/modules/scala-api/src/main/scala-3/org/apache/flinkx/api/LowPrioImplicits.scala
+++ b/modules/scala-api/src/main/scala-3/org/apache/flinkx/api/LowPrioImplicits.scala
@@ -27,6 +27,7 @@ private[api] trait LowPrioImplicits extends TaggedDerivation[TypeInformation]:
       typeTag: TypeTag[T]
   ): Typeclass[T] =
     val cacheKey = typeName(ctx.typeInfo)
+    println(cacheKey)
     cache.get(cacheKey) match
       case Some(cached) =>
         cached.asInstanceOf[TypeInformation[T]]
@@ -55,6 +56,7 @@ private[api] trait LowPrioImplicits extends TaggedDerivation[TypeInformation]:
       typeTag: TypeTag[T]
   ): Typeclass[T] =
     val cacheKey = typeName(ctx.typeInfo)
+    println(cacheKey)
     cache.get(cacheKey) match
       case Some(cached) =>
         cached.asInstanceOf[TypeInformation[T]]

--- a/modules/scala-api/src/main/scala-3/org/apache/flinkx/api/LowPrioImplicits.scala
+++ b/modules/scala-api/src/main/scala-3/org/apache/flinkx/api/LowPrioImplicits.scala
@@ -26,9 +26,9 @@ private[api] trait LowPrioImplicits extends TaggedDerivation[TypeInformation]:
       classTag: ClassTag[T],
       typeTag: TypeTag[T]
   ): Typeclass[T] =
-    val cacheKey = typeName(ctx.typeInfo)
-    println(cacheKey)
-    cache.get(cacheKey) match
+    val useCache = typeTag.isCachable
+    val cacheKey = typeTag.toString
+    Option(useCache).filter(_ == true).flatMap(_ => cache.get(cacheKey)) match
       case Some(cached) =>
         cached.asInstanceOf[TypeInformation[T]]
 
@@ -48,16 +48,16 @@ private[api] trait LowPrioImplicits extends TaggedDerivation[TypeInformation]:
           fieldNames = ctx.params.map(_.label),
           ser = serializer
         ).asInstanceOf[TypeInformation[T]]
-        cache.put(cacheKey, ti)
+        if useCache then cache.put(cacheKey, ti)
         ti
 
   override def split[T](ctx: SealedTrait[Typeclass, T])(using
       classTag: ClassTag[T],
       typeTag: TypeTag[T]
   ): Typeclass[T] =
-    val cacheKey = typeName(ctx.typeInfo)
-    println(cacheKey)
-    cache.get(cacheKey) match
+    val useCache = typeTag.isCachable
+    val cacheKey = typeTag.toString
+    Option(useCache).filter(_ == true).flatMap(_ => cache.get(cacheKey)) match
       case Some(cached) =>
         cached.asInstanceOf[TypeInformation[T]]
 
@@ -68,7 +68,7 @@ private[api] trait LowPrioImplicits extends TaggedDerivation[TypeInformation]:
         )
         val clazz = classTag.runtimeClass.asInstanceOf[Class[T]]
         val ti    = new CoproductTypeInformation[T](clazz, serializer)
-        cache.put(cacheKey, ti)
+        if useCache then cache.put(cacheKey, ti)
         ti
 
   final inline implicit def deriveTypeInformation[T](implicit
@@ -76,6 +76,3 @@ private[api] trait LowPrioImplicits extends TaggedDerivation[TypeInformation]:
       classTag: ClassTag[T],
       typeTag: TypeTag[T]
   ): TypeInformation[T] = derived
-
-  private def typeName(ti: TypeInfo): String =
-    s"${ti.full}[${ti.typeParams.map(typeName).mkString(",")}]"

--- a/modules/scala-api/src/main/scala-3/org/apache/flinkx/api/LowPrioImplicits.scala
+++ b/modules/scala-api/src/main/scala-3/org/apache/flinkx/api/LowPrioImplicits.scala
@@ -57,7 +57,7 @@ private[api] trait LowPrioImplicits extends TaggedDerivation[TypeInformation]:
   ): Typeclass[T] =
     val useCache = typeTag.isCachable
     val cacheKey = typeTag.toString
-    Option(useCache).filter(_ == true).flatMap(_ => cache.get(cacheKey)) match
+    (if useCache then cache.get(cacheKey) else None) match
       case Some(cached) =>
         cached.asInstanceOf[TypeInformation[T]]
 

--- a/modules/scala-api/src/main/scala-3/org/apache/flinkx/api/LowPrioImplicits.scala
+++ b/modules/scala-api/src/main/scala-3/org/apache/flinkx/api/LowPrioImplicits.scala
@@ -28,7 +28,7 @@ private[api] trait LowPrioImplicits extends TaggedDerivation[TypeInformation]:
   ): Typeclass[T] =
     val useCache = typeTag.isCachable
     val cacheKey = typeTag.toString
-    Option(useCache).filter(_ == true).flatMap(_ => cache.get(cacheKey)) match
+    (if useCache then cache.get(cacheKey) else None) match
       case Some(cached) =>
         cached.asInstanceOf[TypeInformation[T]]
 

--- a/modules/scala-api/src/main/scala-3/org/apache/flinkx/api/TypeTag.scala
+++ b/modules/scala-api/src/main/scala-3/org/apache/flinkx/api/TypeTag.scala
@@ -6,6 +6,8 @@ import scala.quoted.*
 trait TypeTag[A]:
   // Is the type a module, i.e. is it a case object?
   def isModule: Boolean
+  def isCachable: Boolean
+  def toString: String
 
 object TypeTag:
   def apply[A: TypeTag]: TypeTag[A] = summon

--- a/modules/scala-api/src/main/scala-3/org/apache/flinkx/api/TypeTagMacro.scala
+++ b/modules/scala-api/src/main/scala-3/org/apache/flinkx/api/TypeTagMacro.scala
@@ -7,12 +7,19 @@ object TypeTagMacro:
   def gen[A: Type](using q: Quotes): Expr[TypeTag[A]] =
     import q.reflect.*
 
-    val A            = TypeRepr.of[A]
-    val symA         = A.typeSymbol
-    val flagsA       = symA.flags
-    val isModuleExpr = Expr(flagsA.is(Flags.Module))
+    val A              = TypeRepr.of[A]
+    val symA           = A.typeSymbol
+    val flagsA         = symA.flags
+    val isModuleExpr   = Expr(flagsA.is(Flags.Module))
+    val isCachableExpr = Expr(A match {
+      case a: AppliedType => !a.args.exists { t => t.typeSymbol.isAbstractType }
+      case _              => true
+    })
+    val toStringExpr   = Expr(A.show)
 
     '{
       new TypeTag[A]:
         override lazy val isModule: Boolean = ${ isModuleExpr }
+        override lazy val isCachable: Boolean = ${ isCachableExpr }
+        override lazy val toString: String = ${ toStringExpr }
     }

--- a/modules/scala-api/src/main/scala-3/org/apache/flinkx/api/TypeTagMacro.scala
+++ b/modules/scala-api/src/main/scala-3/org/apache/flinkx/api/TypeTagMacro.scala
@@ -12,6 +12,7 @@ object TypeTagMacro:
     val flagsA         = symA.flags
     val isModuleExpr   = Expr(flagsA.is(Flags.Module))
     val isCachableExpr = Expr(A match {
+      // this type is not cachable if one of its type args is abstract
       case a: AppliedType => !a.args.exists { t => t.typeSymbol.isAbstractType }
       case _              => true
     })

--- a/modules/scala-api/src/test/scala-2/org/apache/flinkx/api/GenericCaseClassScala2Test.scala
+++ b/modules/scala-api/src/test/scala-2/org/apache/flinkx/api/GenericCaseClassScala2Test.scala
@@ -36,14 +36,15 @@ class GenericCaseClassScala2Test extends AnyFlatSpec with should.Matchers {
 
     if (classOf[Cat].isAssignableFrom(aClass)) {
       aInfo should be theSameInstanceAs catInfo
-      aBasketInfo should be theSameInstanceAs catBasketInfo
+      aBasketInfo should be theSameInstanceAs catBasketInfo // Type info of Basket[A] finds the cached type info of Basket[Cat]
     }
     if (classOf[Dog].isAssignableFrom(aClass)) {
       aInfo should be theSameInstanceAs dogInfo
-      aBasketInfo should be theSameInstanceAs dogBasketInfo
+      aBasketInfo should be theSameInstanceAs dogBasketInfo // Type info of Basket[A] finds the cached type info of Basket[Dog]
     }
     catBasketInfo.asInstanceOf[ProductTypeInformation[A]].getFieldTypes()(0) should be theSameInstanceAs catInfo
     dogBasketInfo.asInstanceOf[ProductTypeInformation[A]].getFieldTypes()(0) should be theSameInstanceAs dogInfo
+    // Type info of Basket[A] holds a type info of the good type (Cat or Dog) found in the cache
     aBasketInfo.asInstanceOf[ProductTypeInformation[A]].getFieldTypes()(0) should be theSameInstanceAs aInfo
   }
 

--- a/modules/scala-api/src/test/scala-2/org/apache/flinkx/api/GenericCaseClassScala2Test.scala
+++ b/modules/scala-api/src/test/scala-2/org/apache/flinkx/api/GenericCaseClassScala2Test.scala
@@ -1,0 +1,67 @@
+package org.apache.flinkx.api
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flinkx.api.serializers._
+import org.apache.flinkx.api.typeinfo.ProductTypeInformation
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+
+// This import is not available in Scala 3
+import scala.reflect.runtime.universe.TypeTag
+
+class GenericCaseClassScala2Test extends AnyFlatSpec with should.Matchers {
+
+  import GenericCaseClassScala2Test._
+
+  "Both TypeInformation of Animal Basket" should "have their respective TypeInformation of Animal" in {
+    typeInformationOfAnimalBasketShouldHaveATypeInformationOfAnimal[Cat](classOf[Cat])
+    // This second call is failing without the fix: TypeInformation of DogBasket hold a wrong TypeInformation of Cat
+    typeInformationOfAnimalBasketShouldHaveATypeInformationOfAnimal[Dog](classOf[Dog])
+  }
+
+  def typeInformationOfAnimalBasketShouldHaveATypeInformationOfAnimal[A <: Animal: TypeTag: TypeInformation](
+      aClass: Class[A]
+  ): Unit = {
+    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Cat[] => OK
+    val catInfo: TypeInformation[Cat]               = implicitly[TypeInformation[Cat]]
+    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Dog[] => OK
+    val dogInfo: TypeInformation[Dog]               = implicitly[TypeInformation[Dog]]
+    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Cat[] or Dog[] => OK
+    val aInfo: TypeInformation[A]                   = implicitly[TypeInformation[A]]
+    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Basket[org.apache.flinkx.api.GenericCaseClassTest.Cat[]] => OK
+    val catBasketInfo: TypeInformation[Basket[Cat]] = implicitly[TypeInformation[Basket[Cat]]]
+    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Basket[org.apache.flinkx.api.GenericCaseClassTest.Dog[]] => OK
+    val dogBasketInfo: TypeInformation[Basket[Dog]] = implicitly[TypeInformation[Basket[Dog]]]
+    // without the fix: cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Basket[org.apache.flinkx.api.GenericCaseClassTest.typeInformationOfAnimalBasketShouldHaveATypeInformationOfAnimal.A[]] => issue
+    // with the fix: cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Basket[org.apache.flinkx.api.GenericCaseClassTest.Cat] or Dog => OK
+    val aBasketInfo: TypeInformation[Basket[A]]     = implicitly[TypeInformation[Basket[A]]]
+
+    if (classOf[Cat].isAssignableFrom(aClass)) {
+      aInfo should be theSameInstanceAs catInfo
+      aBasketInfo should be theSameInstanceAs catBasketInfo // Fails without the fix => cache miss
+    }
+    if (classOf[Dog].isAssignableFrom(aClass)) {
+      aInfo should be theSameInstanceAs dogInfo
+      aBasketInfo should be theSameInstanceAs dogBasketInfo // Fails without the fix => cache miss
+    }
+    catBasketInfo.asInstanceOf[ProductTypeInformation[A]].getFieldTypes()(0) should be theSameInstanceAs catInfo
+    dogBasketInfo.asInstanceOf[ProductTypeInformation[A]].getFieldTypes()(0) should be theSameInstanceAs dogInfo
+
+    // This check is failing on second call without the fix: TypeInformation of DogBasket hold a wrong TypeInformation of Cat
+    aBasketInfo.asInstanceOf[ProductTypeInformation[A]].getFieldTypes()(0) should be theSameInstanceAs aInfo
+  }
+
+}
+
+object GenericCaseClassScala2Test {
+
+  sealed trait Animal extends Product {
+    def name: String
+  }
+
+  case class Cat(name: String) extends Animal
+  case class Dog(name: String) extends Animal
+
+  case class Basket[A <: Animal](animal: A)
+
+}

--- a/modules/scala-api/src/test/scala-2/org/apache/flinkx/api/GenericCaseClassScala2Test.scala
+++ b/modules/scala-api/src/test/scala-2/org/apache/flinkx/api/GenericCaseClassScala2Test.scala
@@ -15,39 +15,35 @@ class GenericCaseClassScala2Test extends AnyFlatSpec with should.Matchers {
 
   "Both TypeInformation of Animal Basket" should "have their respective TypeInformation of Animal" in {
     typeInformationOfAnimalBasketShouldHaveATypeInformationOfAnimal[Cat](classOf[Cat])
-    // This second call is failing without the fix: TypeInformation of DogBasket hold a wrong TypeInformation of Cat
     typeInformationOfAnimalBasketShouldHaveATypeInformationOfAnimal[Dog](classOf[Dog])
   }
 
   def typeInformationOfAnimalBasketShouldHaveATypeInformationOfAnimal[A <: Animal: TypeTag: TypeInformation](
       aClass: Class[A]
   ): Unit = {
-    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Cat[] => OK
+    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Cat => OK
     val catInfo: TypeInformation[Cat]               = implicitly[TypeInformation[Cat]]
-    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Dog[] => OK
+    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Dog => OK
     val dogInfo: TypeInformation[Dog]               = implicitly[TypeInformation[Dog]]
-    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Cat[] or Dog[] => OK
+    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Cat or Dog => OK
     val aInfo: TypeInformation[A]                   = implicitly[TypeInformation[A]]
-    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Basket[org.apache.flinkx.api.GenericCaseClassTest.Cat[]] => OK
+    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Basket[org.apache.flinkx.api.GenericCaseClassTest.Cat] => OK
     val catBasketInfo: TypeInformation[Basket[Cat]] = implicitly[TypeInformation[Basket[Cat]]]
-    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Basket[org.apache.flinkx.api.GenericCaseClassTest.Dog[]] => OK
+    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Basket[org.apache.flinkx.api.GenericCaseClassTest.Dog] => OK
     val dogBasketInfo: TypeInformation[Basket[Dog]] = implicitly[TypeInformation[Basket[Dog]]]
-    // without the fix: cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Basket[org.apache.flinkx.api.GenericCaseClassTest.typeInformationOfAnimalBasketShouldHaveATypeInformationOfAnimal.A[]] => issue
-    // with the fix: cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Basket[org.apache.flinkx.api.GenericCaseClassTest.Cat] or Dog => OK
+    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Basket[org.apache.flinkx.api.GenericCaseClassTest.Cat] or Dog => OK
     val aBasketInfo: TypeInformation[Basket[A]]     = implicitly[TypeInformation[Basket[A]]]
 
     if (classOf[Cat].isAssignableFrom(aClass)) {
       aInfo should be theSameInstanceAs catInfo
-      aBasketInfo should be theSameInstanceAs catBasketInfo // Fails without the fix => cache miss
+      aBasketInfo should be theSameInstanceAs catBasketInfo
     }
     if (classOf[Dog].isAssignableFrom(aClass)) {
       aInfo should be theSameInstanceAs dogInfo
-      aBasketInfo should be theSameInstanceAs dogBasketInfo // Fails without the fix => cache miss
+      aBasketInfo should be theSameInstanceAs dogBasketInfo
     }
     catBasketInfo.asInstanceOf[ProductTypeInformation[A]].getFieldTypes()(0) should be theSameInstanceAs catInfo
     dogBasketInfo.asInstanceOf[ProductTypeInformation[A]].getFieldTypes()(0) should be theSameInstanceAs dogInfo
-
-    // This check is failing on second call without the fix: TypeInformation of DogBasket hold a wrong TypeInformation of Cat
     aBasketInfo.asInstanceOf[ProductTypeInformation[A]].getFieldTypes()(0) should be theSameInstanceAs aInfo
   }
 

--- a/modules/scala-api/src/test/scala-3/org/apache/flinkx/api/GenericCaseClassScala3Test.scala
+++ b/modules/scala-api/src/test/scala-3/org/apache/flinkx/api/GenericCaseClassScala3Test.scala
@@ -19,17 +19,17 @@ class GenericCaseClassScala3Test extends AnyFlatSpec with should.Matchers {
       aClass: Class[A]
   ): Unit = {
     // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Cat => OK
-    val catInfo: TypeInformation[Cat]               = implicitly[TypeInformation[Cat]]
+    val catInfo: TypeInformation[Cat]               = deriveTypeInformation
     // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Dog => OK
-    val dogInfo: TypeInformation[Dog]               = implicitly[TypeInformation[Dog]]
+    val dogInfo: TypeInformation[Dog]               = deriveTypeInformation
     // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Cat or Dog => OK
     val aInfo: TypeInformation[A]                   = implicitly[TypeInformation[A]]
     // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Basket[org.apache.flinkx.api.GenericCaseClassTest.Cat] => OK
-    val catBasketInfo: TypeInformation[Basket[Cat]] = implicitly[TypeInformation[Basket[Cat]]]
+    val catBasketInfo: TypeInformation[Basket[Cat]] = deriveTypeInformation
     // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Basket[org.apache.flinkx.api.GenericCaseClassTest.Dog] => OK
-    val dogBasketInfo: TypeInformation[Basket[Dog]] = implicitly[TypeInformation[Basket[Dog]]]
+    val dogBasketInfo: TypeInformation[Basket[Dog]] = deriveTypeInformation
     // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Basket[A] => Basket[A] is not cachable
-    val aBasketInfo: TypeInformation[Basket[A]]     = implicitly[TypeInformation[Basket[A]]]
+    val aBasketInfo: TypeInformation[Basket[A]]     = deriveTypeInformation
 
     if (classOf[Cat].isAssignableFrom(aClass)) {
       aInfo should be theSameInstanceAs catInfo

--- a/modules/scala-api/src/test/scala-3/org/apache/flinkx/api/GenericCaseClassScala3Test.scala
+++ b/modules/scala-api/src/test/scala-3/org/apache/flinkx/api/GenericCaseClassScala3Test.scala
@@ -12,38 +12,35 @@ class GenericCaseClassScala3Test extends AnyFlatSpec with should.Matchers {
 
   "Both TypeInformation of Animal Basket" should "have their respective TypeInformation of Animal" in {
     typeInformationOfAnimalBasketShouldHaveATypeInformationOfAnimal[Cat](classOf[Cat])
-    // This second call is failing: TypeInformation of DogBasket hold a wrong TypeInformation of Cat
     typeInformationOfAnimalBasketShouldHaveATypeInformationOfAnimal[Dog](classOf[Dog])
   }
 
   def typeInformationOfAnimalBasketShouldHaveATypeInformationOfAnimal[A <: Animal: TypeTag: TypeInformation](
       aClass: Class[A]
   ): Unit = {
-    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Cat[] => OK
+    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Cat => OK
     val catInfo: TypeInformation[Cat]               = implicitly[TypeInformation[Cat]]
-    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Dog[] => OK
+    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Dog => OK
     val dogInfo: TypeInformation[Dog]               = implicitly[TypeInformation[Dog]]
-    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Cat[] or Dog[] => OK
+    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Cat or Dog => OK
     val aInfo: TypeInformation[A]                   = implicitly[TypeInformation[A]]
-    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Basket[org.apache.flinkx.api.GenericCaseClassTest.Cat[]] => OK
+    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Basket[org.apache.flinkx.api.GenericCaseClassTest.Cat] => OK
     val catBasketInfo: TypeInformation[Basket[Cat]] = implicitly[TypeInformation[Basket[Cat]]]
-    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Basket[org.apache.flinkx.api.GenericCaseClassTest.Dog[]] => OK
+    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Basket[org.apache.flinkx.api.GenericCaseClassTest.Dog] => OK
     val dogBasketInfo: TypeInformation[Basket[Dog]] = implicitly[TypeInformation[Basket[Dog]]]
-    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Basket[org.apache.flinkx.api.GenericCaseClassTest.typeInformationOfAnimalBasketShouldHaveATypeInformationOfAnimal.A[]] => issue
+    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Basket[A] => not cached
     val aBasketInfo: TypeInformation[Basket[A]]     = implicitly[TypeInformation[Basket[A]]]
 
     if (classOf[Cat].isAssignableFrom(aClass)) {
       aInfo should be theSameInstanceAs catInfo
-      // aBasketInfo should be theSameInstanceAs catBasketInfo // Fails => cache miss
+      // aBasketInfo should be theSameInstanceAs catBasketInfo // Fails => aBasketInfo is not cached
     }
     if (classOf[Dog].isAssignableFrom(aClass)) {
       aInfo should be theSameInstanceAs dogInfo
-      // aBasketInfo should be theSameInstanceAs dogBasketInfo // Fails => cache miss
+      // aBasketInfo should be theSameInstanceAs dogBasketInfo // Fails => aBasketInfo is not cached
     }
     catBasketInfo.asInstanceOf[ProductTypeInformation[A]].getFieldTypes()(0) should be theSameInstanceAs catInfo
     dogBasketInfo.asInstanceOf[ProductTypeInformation[A]].getFieldTypes()(0) should be theSameInstanceAs dogInfo
-
-    // This check is failing on second call: TypeInformation of DogBasket hold a wrong TypeInformation of Cat
     aBasketInfo.asInstanceOf[ProductTypeInformation[A]].getFieldTypes()(0) should be theSameInstanceAs aInfo
   }
 

--- a/modules/scala-api/src/test/scala-3/org/apache/flinkx/api/GenericCaseClassScala3Test.scala
+++ b/modules/scala-api/src/test/scala-3/org/apache/flinkx/api/GenericCaseClassScala3Test.scala
@@ -28,19 +28,20 @@ class GenericCaseClassScala3Test extends AnyFlatSpec with should.Matchers {
     val catBasketInfo: TypeInformation[Basket[Cat]] = implicitly[TypeInformation[Basket[Cat]]]
     // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Basket[org.apache.flinkx.api.GenericCaseClassTest.Dog] => OK
     val dogBasketInfo: TypeInformation[Basket[Dog]] = implicitly[TypeInformation[Basket[Dog]]]
-    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Basket[A] => not cached
+    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Basket[A] => Basket[A] is not cachable
     val aBasketInfo: TypeInformation[Basket[A]]     = implicitly[TypeInformation[Basket[A]]]
 
     if (classOf[Cat].isAssignableFrom(aClass)) {
       aInfo should be theSameInstanceAs catInfo
-      // aBasketInfo should be theSameInstanceAs catBasketInfo // Fails => aBasketInfo is not cached
+      aBasketInfo shouldNot be theSameInstanceAs catBasketInfo // Basket[A] is not cachable
     }
     if (classOf[Dog].isAssignableFrom(aClass)) {
       aInfo should be theSameInstanceAs dogInfo
-      // aBasketInfo should be theSameInstanceAs dogBasketInfo // Fails => aBasketInfo is not cached
+      aBasketInfo shouldNot be theSameInstanceAs dogBasketInfo // Basket[A] is not cachable
     }
     catBasketInfo.asInstanceOf[ProductTypeInformation[A]].getFieldTypes()(0) should be theSameInstanceAs catInfo
     dogBasketInfo.asInstanceOf[ProductTypeInformation[A]].getFieldTypes()(0) should be theSameInstanceAs dogInfo
+    // Type info of Basket[A] is not cached, but it holds a type info of the good type (Cat or Dog) found in the cache
     aBasketInfo.asInstanceOf[ProductTypeInformation[A]].getFieldTypes()(0) should be theSameInstanceAs aInfo
   }
 

--- a/modules/scala-api/src/test/scala-3/org/apache/flinkx/api/GenericCaseClassScala3Test.scala
+++ b/modules/scala-api/src/test/scala-3/org/apache/flinkx/api/GenericCaseClassScala3Test.scala
@@ -1,0 +1,63 @@
+package org.apache.flinkx.api
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flinkx.api.serializers._
+import org.apache.flinkx.api.typeinfo.ProductTypeInformation
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+
+class GenericCaseClassScala3Test extends AnyFlatSpec with should.Matchers {
+
+  import GenericCaseClassScala3Test._
+
+  "Both TypeInformation of Animal Basket" should "have their respective TypeInformation of Animal" in {
+    typeInformationOfAnimalBasketShouldHaveATypeInformationOfAnimal[Cat](classOf[Cat])
+    // This second call is failing: TypeInformation of DogBasket hold a wrong TypeInformation of Cat
+    typeInformationOfAnimalBasketShouldHaveATypeInformationOfAnimal[Dog](classOf[Dog])
+  }
+
+  def typeInformationOfAnimalBasketShouldHaveATypeInformationOfAnimal[A <: Animal: TypeTag: TypeInformation](
+      aClass: Class[A]
+  ): Unit = {
+    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Cat[] => OK
+    val catInfo: TypeInformation[Cat]               = implicitly[TypeInformation[Cat]]
+    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Dog[] => OK
+    val dogInfo: TypeInformation[Dog]               = implicitly[TypeInformation[Dog]]
+    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Cat[] or Dog[] => OK
+    val aInfo: TypeInformation[A]                   = implicitly[TypeInformation[A]]
+    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Basket[org.apache.flinkx.api.GenericCaseClassTest.Cat[]] => OK
+    val catBasketInfo: TypeInformation[Basket[Cat]] = implicitly[TypeInformation[Basket[Cat]]]
+    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Basket[org.apache.flinkx.api.GenericCaseClassTest.Dog[]] => OK
+    val dogBasketInfo: TypeInformation[Basket[Dog]] = implicitly[TypeInformation[Basket[Dog]]]
+    // cacheKey=org.apache.flinkx.api.GenericCaseClassTest.Basket[org.apache.flinkx.api.GenericCaseClassTest.typeInformationOfAnimalBasketShouldHaveATypeInformationOfAnimal.A[]] => issue
+    val aBasketInfo: TypeInformation[Basket[A]]     = implicitly[TypeInformation[Basket[A]]]
+
+    if (classOf[Cat].isAssignableFrom(aClass)) {
+      aInfo should be theSameInstanceAs catInfo
+      // aBasketInfo should be theSameInstanceAs catBasketInfo // Fails => cache miss
+    }
+    if (classOf[Dog].isAssignableFrom(aClass)) {
+      aInfo should be theSameInstanceAs dogInfo
+      // aBasketInfo should be theSameInstanceAs dogBasketInfo // Fails => cache miss
+    }
+    catBasketInfo.asInstanceOf[ProductTypeInformation[A]].getFieldTypes()(0) should be theSameInstanceAs catInfo
+    dogBasketInfo.asInstanceOf[ProductTypeInformation[A]].getFieldTypes()(0) should be theSameInstanceAs dogInfo
+
+    // This check is failing on second call: TypeInformation of DogBasket hold a wrong TypeInformation of Cat
+    aBasketInfo.asInstanceOf[ProductTypeInformation[A]].getFieldTypes()(0) should be theSameInstanceAs aInfo
+  }
+
+}
+
+object GenericCaseClassScala3Test {
+
+  sealed trait Animal extends Product {
+    def name: String
+  }
+
+  case class Cat(name: String) extends Animal
+  case class Dog(name: String) extends Animal
+
+  case class Basket[A <: Animal](animal: A)
+
+}


### PR DESCRIPTION
This PR is a work in progress to allow to reproduce the issue described #206 and to propose a fix for Scala 2.

The root cause of the problem comes from magnolia `TypeName` used as cache key: `TypeName.typeArguments` are not resolved with the concrete types (`Basket[Cat]`) but keep referencing the unresolved abstract types (`Basket[A]`).

In Scala 2, the fix is simply to replace usage of magnolia `TypeName` in favor of `TypeTag` which resolve correctly type parameters to concrete types.

Unfortunately, this fix is not working in Scala 3 because there is no `TypeTag` and the one you are creating yourself seems to not have enough information.

I don't know the best way to fix it for Scala 3, maybe by improving your `TypeTag` implementation or maybe by finding more type parameters information with magnolia `TypeInfo`.

I prefer to let you handle the fix for Scala 3 as I have no experience with it and what you did with your `TypeTag` implementation.

Please note `GenericCaseClassScala2Test` seems to be not executed with a `sbt test`, maybe I missed a configuration in `build.sbt`? The test is working when executed in IDE.

Thanks.