### PR TITLE
feat(#187): fail-fast on Scala type resolution with Class

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ However, this project cannot enforce TypeInformation usage in the Flink Java API
 
 Usage of this code may lead to silently fallback to Kryo.
 
+From Flink 1.19, a check is done to detect this misusage. To disable it, see [Disable fail-fast on Scala type resolution with Class feature flag](#disable-fail-fast-on-scala-type-resolution-with-class).
+
 > [!WARNING]  
 > Official `flink-scala` deprecated dependency contains Scala-specialized Kryo serializers. If this dependency is removed from the classpath (see [Supported Flink versions](#supported-flink-versions)), usage of Kryo with Scala classes leads to erroneous re-instantiations of `object` and `case object` singletons.
 > 
@@ -402,7 +404,7 @@ env
 
 In the [1.1.5 release](https://github.com/flink-extended/flink-scala-api/releases/tag/v1.18.1_1.1.5) the Case Class serialization process also [stores case class arity](https://github.com/flink-extended/flink-scala-api/pull/98/files#diff-e896c210d6a754cb3afb462aea34cca08f090330f6f3c663a64dfb5584fc3727R106) number to
 a savepoint. This was introduced to support Case Class schema evolution and allow to add new
-class fields with default values. However, unfortunatelly this is the breaking change to the Flink job state restore process. Flink job will fail, if
+class fields with default values. However, unfortunately this is the breaking change to the Flink job state restore process. Flink job will fail, if
 a savepoint used for the job restore was created by 1.1.4 or earlier releases.
 
 In order migrate to the 1.1.5 release version, one can use specially added environment variable:
@@ -412,11 +414,17 @@ To disable new savepoint format and be able to restore a Flink job with a savepo
 
 Example: `DISABLE_CASE_CLASS_ARITY_USAGE = true`
 
-To enbale new serialization logic set this variable to `false` or simply do not define this envrionment vairable.
+To enable new serialization logic set this variable to `false` or simply do not define this environment variable.
 
 Example: `DISABLE_CASE_CLASS_ARITY_USAGE = false`
 
 P.S. this flag can be deprecated in future when most of the users migrate to the latest library version.
+
+### Disable fail-fast on Scala type resolution with Class
+
+From [1.3.0 release](https://github.com/flink-extended/flink-scala-api/releases/tag/v1.19.1_1.3.0), a check is done to prevent misusage of Scala type resolution with `Class` which may lead to silently fallback to generic Kryo serializers.
+
+You can disable this check with the `DISABLE_FAIL_FAST_ON_SCALA_TYPE_RESOLUTION_WITH_CLASS` environment variable set to `true`.
 
 ## Release
 

--- a/modules/scala-api/src/main/scala/org/apache/flinkx/api/StreamExecutionEnvironment.scala
+++ b/modules/scala-api/src/main/scala/org/apache/flinkx/api/StreamExecutionEnvironment.scala
@@ -977,7 +977,7 @@ object StreamExecutionEnvironment {
       serializationConfig.add("scala.util.Either: {type: typeinfo, class: org.apache.flinkx.api.typeinfo.FailFastTypeInfoFactory}")
       serializationConfig.add("scala.Array: {type: typeinfo, class: org.apache.flinkx.api.typeinfo.FailFastTypeInfoFactory}")
       serializationConfig.add("scala.collection.Iterable: {type: typeinfo, class: org.apache.flinkx.api.typeinfo.FailFastTypeInfoFactory}")
-      config.clone().set(serializationOption, serializationConfig)
+      new Configuration(config).set(serializationOption, serializationConfig)
     } else {
       config
     }

--- a/modules/scala-api/src/main/scala/org/apache/flinkx/api/StreamExecutionEnvironment.scala
+++ b/modules/scala-api/src/main/scala/org/apache/flinkx/api/StreamExecutionEnvironment.scala
@@ -827,9 +827,8 @@ object StreamExecutionEnvironment {
     * cluster.
     */
   def getExecutionEnvironment: StreamExecutionEnvironment = {
-    val configuration = new Configuration
-    configureFailFastOnScalaTypeResolutionWithClass(configuration)
-    new StreamExecutionEnvironment(JavaEnv.getExecutionEnvironment(configuration))
+    val extraConfig = copyWithExtra(new Configuration)
+    new StreamExecutionEnvironment(JavaEnv.getExecutionEnvironment(extraConfig))
   }
 
   /** Creates an execution environment that represents the context in which the program is currently executed.
@@ -838,8 +837,8 @@ object StreamExecutionEnvironment {
     *   Pass a custom configuration into the cluster.
     */
   def getExecutionEnvironment(configuration: Configuration): StreamExecutionEnvironment = {
-    configureFailFastOnScalaTypeResolutionWithClass(configuration)
-    new StreamExecutionEnvironment(JavaEnv.getExecutionEnvironment(configuration))
+    val extraConfig = copyWithExtra(configuration)
+    new StreamExecutionEnvironment(JavaEnv.getExecutionEnvironment(extraConfig))
   }
 
   // --------------------------------------------------------------------------
@@ -853,9 +852,8 @@ object StreamExecutionEnvironment {
     * [[setDefaultLocalParallelism(Int)]].
     */
   def createLocalEnvironment(parallelism: Int = JavaEnv.getDefaultLocalParallelism): StreamExecutionEnvironment = {
-    val configuration = new Configuration
-    configureFailFastOnScalaTypeResolutionWithClass(configuration)
-    new StreamExecutionEnvironment(JavaEnv.createLocalEnvironment(parallelism, configuration))
+    val extraConfig = copyWithExtra(new Configuration)
+    new StreamExecutionEnvironment(JavaEnv.createLocalEnvironment(parallelism, extraConfig))
   }
 
   /** Creates a local execution environment. The local execution environment will run the program in a multi-threaded
@@ -867,8 +865,8 @@ object StreamExecutionEnvironment {
     *   Pass a custom configuration into the cluster.
     */
   def createLocalEnvironment(parallelism: Int, configuration: Configuration): StreamExecutionEnvironment = {
-    configureFailFastOnScalaTypeResolutionWithClass(configuration)
-    new StreamExecutionEnvironment(JavaEnv.createLocalEnvironment(parallelism, configuration))
+    val extraConfig = copyWithExtra(configuration)
+    new StreamExecutionEnvironment(JavaEnv.createLocalEnvironment(parallelism, extraConfig))
   }
 
   /** Creates a [[StreamExecutionEnvironment]] for local program execution that also starts the web monitoring UI.
@@ -886,9 +884,8 @@ object StreamExecutionEnvironment {
     */
   @PublicEvolving
   def createLocalEnvironmentWithWebUI(config: Configuration = null): StreamExecutionEnvironment = {
-    val conf: Configuration = if (config == null) new Configuration() else config
-    configureFailFastOnScalaTypeResolutionWithClass(conf)
-    new StreamExecutionEnvironment(JavaEnv.createLocalEnvironmentWithWebUI(conf))
+    val extraConfig = copyWithExtra(if (config == null) new Configuration() else config)
+    new StreamExecutionEnvironment(JavaEnv.createLocalEnvironmentWithWebUI(extraConfig))
   }
 
   // --------------------------------------------------------------------------
@@ -909,9 +906,8 @@ object StreamExecutionEnvironment {
     *   user-defined input formats, or any libraries, those must be provided in the JAR files.
     */
   def createRemoteEnvironment(host: String, port: Int, jarFiles: String*): StreamExecutionEnvironment = {
-    val configuration = new Configuration
-    configureFailFastOnScalaTypeResolutionWithClass(configuration)
-    new StreamExecutionEnvironment(JavaEnv.createRemoteEnvironment(host, port, configuration, jarFiles: _*))
+    val extraConfig = copyWithExtra(new Configuration)
+    new StreamExecutionEnvironment(JavaEnv.createRemoteEnvironment(host, port, extraConfig, jarFiles: _*))
   }
 
   /** Creates a remote execution environment. The remote environment sends (parts of) the program to a cluster for
@@ -934,9 +930,8 @@ object StreamExecutionEnvironment {
       parallelism: Int,
       jarFiles: String*
   ): StreamExecutionEnvironment = {
-    val configuration = new Configuration
-    configureFailFastOnScalaTypeResolutionWithClass(configuration)
-    val javaEnv = JavaEnv.createRemoteEnvironment(host, port, configuration, jarFiles: _*)
+    val extraConfig = copyWithExtra(new Configuration)
+    val javaEnv = JavaEnv.createRemoteEnvironment(host, port, extraConfig, jarFiles: _*)
     javaEnv.setParallelism(parallelism)
     new StreamExecutionEnvironment(javaEnv)
   }
@@ -949,7 +944,7 @@ object StreamExecutionEnvironment {
     *   The host name or address of the master (JobManager), where the program should be executed.
     * @param port
     *   The port of the master (JobManager), where the program should be executed.
-    * @param configuration
+    * @param config
     *   Pass a custom configuration into the cluster.
     * @param jarFiles
     *   The JAR files with code that needs to be shipped to the cluster. If the program uses user-defined functions,
@@ -961,22 +956,30 @@ object StreamExecutionEnvironment {
       config: Configuration,
       jarFiles: String*
   ): StreamExecutionEnvironment = {
-    configureFailFastOnScalaTypeResolutionWithClass(config)
-    val javaEnv = JavaEnv.createRemoteEnvironment(host, port, config, jarFiles: _*)
+    val extraConfig = copyWithExtra(config)
+    val javaEnv = JavaEnv.createRemoteEnvironment(host, port, extraConfig, jarFiles: _*)
     new StreamExecutionEnvironment(javaEnv)
   }
 
-  private def configureFailFastOnScalaTypeResolutionWithClass(configuration: Configuration): Unit = {
+  /**
+   * Copy input config and add extra configuration:
+   *  - register type info factories to fail-fast on Scala type resolution with Class
+   * @param config input configuration
+   * @return a copy of input config with extra configuration
+   */
+  private def copyWithExtra(config: Configuration): Configuration = {
     if (!isFailFastOnScalaTypeResolutionWithClassConfigured && !isFailFastOnScalaTypeResolutionWithClassDisabled) {
       isFailFastOnScalaTypeResolutionWithClassConfigured = true
       val serializationOption = ConfigOptions.key("pipeline.serialization-config").stringType().asList().noDefaultValue()
-      val serializationConfig = configuration.getOptional(serializationOption).orElse(new util.ArrayList[String])
+      val serializationConfig = config.getOptional(serializationOption).orElse(new util.ArrayList[String])
       serializationConfig.add("scala.Product: {type: typeinfo, class: org.apache.flinkx.api.typeinfo.FailFastTypeInfoFactory}")
       serializationConfig.add("scala.Option: {type: typeinfo, class: org.apache.flinkx.api.typeinfo.FailFastTypeInfoFactory}")
       serializationConfig.add("scala.util.Either: {type: typeinfo, class: org.apache.flinkx.api.typeinfo.FailFastTypeInfoFactory}")
       serializationConfig.add("scala.Array: {type: typeinfo, class: org.apache.flinkx.api.typeinfo.FailFastTypeInfoFactory}")
       serializationConfig.add("scala.collection.Iterable: {type: typeinfo, class: org.apache.flinkx.api.typeinfo.FailFastTypeInfoFactory}")
-      configuration.set(serializationOption, serializationConfig)
+      config.clone().set(serializationOption, serializationConfig)
+    } else {
+      config
     }
   }
 

--- a/modules/scala-api/src/main/scala/org/apache/flinkx/api/StreamExecutionEnvironment.scala
+++ b/modules/scala-api/src/main/scala/org/apache/flinkx/api/StreamExecutionEnvironment.scala
@@ -967,7 +967,8 @@ object StreamExecutionEnvironment {
   }
 
   private def configureFailFastOnScalaTypeResolutionWithClass(configuration: Configuration): Unit = {
-    if (!isFailFastOnScalaTypeResolutionWithClassDisabled) {
+    if (!isFailFastOnScalaTypeResolutionWithClassConfigured && !isFailFastOnScalaTypeResolutionWithClassDisabled) {
+      isFailFastOnScalaTypeResolutionWithClassConfigured = true
       val serializationOption = ConfigOptions.key("pipeline.serialization-config").stringType().asList().noDefaultValue()
       val serializationConfig = configuration.getOptional(serializationOption).orElse(new util.ArrayList[String])
       serializationConfig.add("scala.Product: {type: typeinfo, class: org.apache.flinkx.api.typeinfo.FailFastTypeInfoFactory}")
@@ -978,6 +979,8 @@ object StreamExecutionEnvironment {
       configuration.set(serializationOption, serializationConfig)
     }
   }
+
+  private var isFailFastOnScalaTypeResolutionWithClassConfigured: Boolean = false
 
   private lazy val isFailFastOnScalaTypeResolutionWithClassDisabled: Boolean =
     sys.env

--- a/modules/scala-api/src/main/scala/org/apache/flinkx/api/typeinfo/FailFastTypeInfoFactory.scala
+++ b/modules/scala-api/src/main/scala/org/apache/flinkx/api/typeinfo/FailFastTypeInfoFactory.scala
@@ -1,0 +1,30 @@
+package org.apache.flinkx.api.typeinfo
+
+import org.apache.flink.api.common.typeinfo.{TypeInfoFactory, TypeInformation}
+import org.apache.flink.util.FlinkRuntimeException
+import org.apache.flinkx.api.typeinfo.FailFastTypeInfoFactory.formatType
+
+import java.lang.reflect.Type
+import java.util
+import scala.jdk.CollectionConverters._
+
+class FailFastTypeInfoFactory extends TypeInfoFactory[Nothing] {
+
+  override def createTypeInfo(t: Type, params: util.Map[String, TypeInformation[_]]): TypeInformation[Nothing] =
+    throw new FlinkRuntimeException(
+      s"""You are using a 'Class' to resolve '${formatType(t, params)}' Scala type. flink-scala-api has no control over this kind of type resolution which may lead to silently fallback to generic Kryo serializers.
+         |Use type information instead: import 'org.apache.flinkx.api.serializers._' to make implicitly available in the scope required 'TypeInformation' to resolve Scala types.
+         |To disable this check, set 'DISABLE_FAIL_FAST_ON_SCALA_TYPE_RESOLUTION_WITH_CLASS' environment variable to 'true'.""".stripMargin
+    )
+
+}
+
+object FailFastTypeInfoFactory {
+
+  private def formatType(t: Type, params: util.Map[String, TypeInformation[_]]): String = if (params.isEmpty) {
+    t.getTypeName
+  } else {
+    params.keySet().asScala.mkString(s"${t.getTypeName}[", ", ", "]")
+  }
+
+}

--- a/modules/scala-api/src/test/scala/org/apache/flinkx/api/StreamExecutionEnvironmentTest.scala
+++ b/modules/scala-api/src/test/scala/org/apache/flinkx/api/StreamExecutionEnvironmentTest.scala
@@ -5,8 +5,11 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.connector.source.Boundedness
 import org.apache.flink.api.connector.source.mocks.MockSource
 import org.apache.flink.api.java.typeutils.GenericTypeInfo
+import org.apache.flink.util.FlinkRuntimeException
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.{Failure, Success, Try}
 
 class StreamExecutionEnvironmentTest extends AnyFlatSpec with Matchers with IntegrationTest {
 
@@ -29,6 +32,24 @@ class StreamExecutionEnvironmentTest extends AnyFlatSpec with Matchers with Inte
     val stream = env.fromSequence(1, 100)
 
     stream.dataType shouldBe typeInfo
+  }
+
+  "From Flink 1.19, TypeInformation.of(Class)" should "fail-fast trying to resolve Scala type" in {
+    Try(Class.forName("org.apache.flink.configuration.PipelineOptions").getField("SERIALIZATION_CONFIG")) match {
+      case Failure(_) => // Before Flink 1.19: no fail-fast, exception happens at execution
+        implicit val typeInfo: TypeInformation[Option[Int]] = TypeInformation.of(classOf[Option[Int]])
+        val stream = env.fromElements(Some(1), None, Some(100))
+        val exception = intercept[UnsupportedOperationException] {
+          stream.executeAndCollect(3)
+        }
+        exception.getMessage should startWith("Generic types have been disabled in the ExecutionConfig and type scala.Option is treated as a generic type.")
+
+      case Success(_) => // From Flink 1.19: fail-fast at Scala type resolution
+        val exception = intercept[FlinkRuntimeException] {
+          TypeInformation.of(classOf[Option[Int]])
+        }
+        exception.getMessage should startWith("You are using a 'Class' to resolve 'scala.Option' Scala type.")
+    }
   }
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
Hi @novakov-alexey,

Here is the PR discussed in issue #187.

About your questions in the issue:
1. Yes, there is no difference between Scala versions, it's just a matter of Flink configuration.
2. As you can see in the PR, `pipeline.serialization-config` property do nothing before Flink 1.19, so there is no need to drop support. When 1.18 support will be dropped, we'll be able to use `PipelineOptions.SERIALIZATION_CONFIG` constant and simplify the test.

Is the modification in the readme and explanations given by the exception clear enough to you? 

Thanks