### PR TITLE
Fix UnitTypeInformation equality logic

### DIFF
--- a/modules/scala-api/src/main/scala/org/apache/flinkx/api/typeinfo/UnitTypeInformation.scala
+++ b/modules/scala-api/src/main/scala/org/apache/flinkx/api/typeinfo/UnitTypeInformation.scala
@@ -10,7 +10,7 @@ class UnitTypeInformation extends TypeInformation[Unit] {
   override def isKeyType: Boolean                                              = true
   override def getTotalFields: Int                                             = 0
   override def isTupleType: Boolean                                            = false
-  override def canEqual(obj: Any): Boolean                                     = obj.isInstanceOf[Unit]
+  override def canEqual(obj: Any): Boolean                                     = obj.isInstanceOf[UnitTypeInformation]
   override def getTypeClass: Class[Unit]                                       = classOf[Unit]
   override def getArity: Int                                                   = 0
   override def isBasicType: Boolean                                            = false
@@ -18,8 +18,8 @@ class UnitTypeInformation extends TypeInformation[Unit] {
   override def toString: String = "{}"
 
   override def equals(obj: Any): Boolean = obj match {
-    case _: Unit => true
-    case _       => false
+    case _: UnitTypeInformation => true
+    case _                      => false
   }
 
   override def hashCode(): Int = ().hashCode()


### PR DESCRIPTION
Hi,
I came across a runtime error when using `Unit` type as a key of ConnectedStream. ([Flink source](https://github.com/apache/flink/blob/ef09e1716924d1e6ed64bfc273859f2de979b027/flink-runtime/src/main/java/org/apache/flink/streaming/api/datastream/ConnectedStreams.java#L502))

When compared to others like `OptionTypeInfo`, I found out that `UnitTypeInformation` has wrong equality check logic.