### PR TITLE
Don't cache nested classes with generic type parameters

### DIFF
--- a/modules/flink-1-api/src/test/scala-3/org/apache/flinkx/api/GenericCaseClassScala3Test.scala
+++ b/modules/flink-1-api/src/test/scala-3/org/apache/flinkx/api/GenericCaseClassScala3Test.scala
@@ -47,47 +47,17 @@ class GenericCaseClassScala3Test extends AnyFlatSpec with should.Matchers {
   }
 
   "Nested generics" should "be resolved correctly" in {
-    println("int")
     val intTypeInfo: TypeInformation[Option[Option[Int]]] = generateTypeInfo[Int]
-    println("string")
     val stringTypeInfo: TypeInformation[Option[Option[String]]] = generateTypeInfo[String]
 
-    val intSerializer = intTypeInfo
-      .asInstanceOf[CoproductTypeInformation[Option[Option[Int]]]]
-      .ser
-      .asInstanceOf[CoproductSerializer[Option[Int]]]
-      .sers(1)
-      .asInstanceOf[ScalaCaseClassSerializer[Option[Int]]]
-
-    val stringSerializer = stringTypeInfo
-      .asInstanceOf[CoproductTypeInformation[Option[Option[String]]]]
-      .ser
-      .asInstanceOf[CoproductSerializer[Option[String]]]
-      .sers(1)
-      .asInstanceOf[ScalaCaseClassSerializer[Option[String]]]
-
-    stringSerializer shouldNot be theSameInstanceAs intSerializer
+    intTypeInfo shouldNot be theSameInstanceAs stringTypeInfo
   }
 
   it should "work with multiple type parameters" in {
     val intTypeInfo  = generateEitherTypeInfo[Int]
     val boolTypeInfo = generateEitherTypeInfo[Boolean]
 
-    val intSerializer = intTypeInfo
-      .asInstanceOf[CoproductTypeInformation[Either[Option[Int], Int]]]
-      .ser
-      .asInstanceOf[CoproductSerializer[Option[Int]]]
-      .sers(1)
-      .asInstanceOf[ScalaCaseClassSerializer[Option[Int]]]
-
-    val boolSerializer = boolTypeInfo
-      .asInstanceOf[CoproductTypeInformation[Either[Option[Boolean], Int]]]
-      .ser
-      .asInstanceOf[CoproductSerializer[Option[Boolean]]]
-      .sers(1)
-      .asInstanceOf[ScalaCaseClassSerializer[Option[Boolean]]]
-
-    boolSerializer shouldNot be theSameInstanceAs intSerializer
+    intTypeInfo shouldNot be theSameInstanceAs boolTypeInfo
 
   }
 

--- a/modules/flink-common-api/src/main/scala-3/org/apache/flinkx/api/TypeTagMacro.scala
+++ b/modules/flink-common-api/src/main/scala-3/org/apache/flinkx/api/TypeTagMacro.scala
@@ -7,15 +7,19 @@ object TypeTagMacro:
   def gen[A: Type](using q: Quotes): Expr[TypeTag[A]] =
     import q.reflect.*
 
-    val A            = TypeRepr.of[A]
-    val symA         = A.typeSymbol
-    val flagsA       = symA.flags
-    val isModuleExpr = Expr(flagsA.is(Flags.Module))
-    val isCachableExpr = Expr(A match {
-      // this type is not cachable if one of its type args is abstract
-      case a: AppliedType => !a.args.exists { t => t.typeSymbol.isAbstractType }
-      case _              => true
-    })
+    def check(r: TypeRepr): Boolean =
+      r match {
+        case a: AppliedType =>
+          !a.args.exists { t => t.typeSymbol.isAbstractType } && a.args.forall { t => check(t) }
+        case _ => true
+      }
+
+    val A              = TypeRepr.of[A]
+    val symA           = A.typeSymbol
+    val flagsA         = symA.flags
+    val isModuleExpr   = Expr(flagsA.is(Flags.Module))
+    val isCachableExpr = Expr(check(A))
+
     val toStringExpr = Expr(A.show)
 
     '{


### PR DESCRIPTION
A potential solution for #242, changes isCachableExpr to recursively inspect the arguments to see if there's a generic parameter.

There may well be better way to do this, I'm not too familiar with scala 3 macros.