### PR TITLE
Fix detection of immutability in case class with private field

### DIFF
--- a/modules/flink-1-api/src/main/scala-2/org/apache/flinkx/api/LowPrioImplicits.scala
+++ b/modules/flink-1-api/src/main/scala-2/org/apache/flinkx/api/LowPrioImplicits.scala
@@ -5,8 +5,8 @@ import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flinkx.api.serializer.{CoproductSerializer, CaseClassSerializer, ScalaCaseObjectSerializer}
 import org.apache.flinkx.api.typeinfo.{CoproductTypeInformation, ProductTypeInformation}
+import org.apache.flinkx.api.util.ClassUtil.isFieldFinal
 
-import java.lang.reflect.{Field, Modifier}
 import scala.collection.mutable
 import scala.language.experimental.macros
 import scala.reflect._
@@ -65,15 +65,6 @@ private[api] trait LowPrioImplicits {
   }
 
   private def typeName[T: TypeTag]: String = typeOf[T].toString
-
-  private def isFieldFinal(fields: Array[Field], className: String, fieldName: String): Boolean =
-    Modifier.isFinal(
-      fields
-        .find(f => f.getName == fieldName)
-        .orElse(fields.find(f => f.getName == s"${className.replace('.', '$')}$$$$$fieldName"))
-        .getOrElse(throw new NoSuchFieldException(fieldName)) // Same as Class.getDeclaredField
-        .getModifiers
-    )
 
   implicit def deriveTypeInformation[T]: TypeInformation[T] = macro Magnolia.gen[T]
 }

--- a/modules/flink-1-api/src/main/scala-3/org/apache/flinkx/api/LowPrioImplicits.scala
+++ b/modules/flink-1-api/src/main/scala-3/org/apache/flinkx/api/LowPrioImplicits.scala
@@ -1,6 +1,5 @@
 package org.apache.flinkx.api
 
-import java.lang.reflect.{Field, Modifier}
 import scala.collection.mutable
 import scala.compiletime.summonInline
 import scala.deriving.Mirror
@@ -11,6 +10,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flinkx.api.serializer.{CaseClassSerializer, CoproductSerializer, ScalaCaseObjectSerializer}
 import org.apache.flinkx.api.typeinfo.{CoproductTypeInformation, ProductTypeInformation}
+import org.apache.flinkx.api.util.ClassUtil.isFieldFinal
 
 private[api] trait LowPrioImplicits extends TaggedDerivation[TypeInformation]:
   type Typeclass[T] = TypeInformation[T]
@@ -71,15 +71,6 @@ private[api] trait LowPrioImplicits extends TaggedDerivation[TypeInformation]:
         val ti    = new CoproductTypeInformation[T](clazz, serializer)
         if useCache then cache.put(cacheKey, ti)
         ti
-
-  private def isFieldFinal(fields: Array[Field], className: String, fieldName: String): Boolean =
-    Modifier.isFinal(
-      fields
-        .find(f => f.getName == fieldName)
-        .orElse(fields.find(f => f.getName == s"${className.replace('.', '$')}$$$$$fieldName"))
-        .getOrElse(throw new NoSuchFieldException(fieldName)) // Same as Class.getDeclaredField
-        .getModifiers
-    )
 
   final inline implicit def deriveTypeInformation[T](implicit
       m: Mirror.Of[T],

--- a/modules/flink-1-api/src/main/scala-3/org/apache/flinkx/api/LowPrioImplicits.scala
+++ b/modules/flink-1-api/src/main/scala-3/org/apache/flinkx/api/LowPrioImplicits.scala
@@ -1,5 +1,6 @@
 package org.apache.flinkx.api
 
+import java.lang.reflect.{Field, Modifier}
 import scala.collection.mutable
 import scala.compiletime.summonInline
 import scala.deriving.Mirror
@@ -10,8 +11,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializer
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flinkx.api.serializer.{CaseClassSerializer, CoproductSerializer, ScalaCaseObjectSerializer}
 import org.apache.flinkx.api.typeinfo.{CoproductTypeInformation, ProductTypeInformation}
-
-import java.lang.reflect.Modifier
 
 private[api] trait LowPrioImplicits extends TaggedDerivation[TypeInformation]:
   type Typeclass[T] = TypeInformation[T]
@@ -37,12 +36,12 @@ private[api] trait LowPrioImplicits extends TaggedDerivation[TypeInformation]:
         val serializer =
           if typeTag.isModule then new ScalaCaseObjectSerializer[T & Product](clazz)
           else
+            val fields = clazz.getDeclaredFields
             new CaseClassSerializer[T & Product](
               clazz = clazz,
               scalaFieldSerializers =
                 IArray.genericWrapArray(ctx.params.map(_.typeclass.createSerializer(config))).toArray,
-              isCaseClassImmutable =
-                ctx.params.forall(p => Modifier.isFinal(clazz.getDeclaredField(p.label).getModifiers))
+              isCaseClassImmutable = ctx.params.forall(p => isFieldFinal(fields, clazz.getName, p.label))
             )
         val ti = new ProductTypeInformation[T & Product](
           c = clazz,
@@ -72,6 +71,15 @@ private[api] trait LowPrioImplicits extends TaggedDerivation[TypeInformation]:
         val ti    = new CoproductTypeInformation[T](clazz, serializer)
         if useCache then cache.put(cacheKey, ti)
         ti
+
+  private def isFieldFinal(fields: Array[Field], className: String, fieldName: String): Boolean =
+    Modifier.isFinal(
+      fields
+        .find(f => f.getName == fieldName)
+        .orElse(fields.find(f => f.getName == s"${className.replace('.', '$')}$$$$$fieldName"))
+        .getOrElse(throw new NoSuchFieldException(fieldName)) // Same as Class.getDeclaredField
+        .getModifiers
+    )
 
   final inline implicit def deriveTypeInformation[T](implicit
       m: Mirror.Of[T],

--- a/modules/flink-1-api/src/test/scala/org/apache/flinkx/api/SerializerTest.scala
+++ b/modules/flink-1-api/src/test/scala/org/apache/flinkx/api/SerializerTest.scala
@@ -3,31 +3,7 @@ package org.apache.flinkx.api
 import cats.data.NonEmptyList
 import org.apache.flinkx.api.SerializerTest.DeeplyNested.ModeNested.SuperNested.{Egg, Food}
 import org.apache.flinkx.api.SerializerTest.NestedRoot.NestedMiddle.NestedBottom
-import org.apache.flinkx.api.SerializerTest.{
-  ADT,
-  ADT2,
-  Ann,
-  Annotated,
-  Bar,
-  Bar2,
-  BoundADT,
-  Foo,
-  Foo2,
-  Generic,
-  JavaTime,
-  ListADT,
-  Nested,
-  P2,
-  Param,
-  Simple,
-  SimpleEither,
-  SimpleJava,
-  SimpleList,
-  SimpleOption,
-  SimpleSeq,
-  SimpleSeqSeq,
-  WrappedADT
-}
+import org.apache.flinkx.api.SerializerTest._
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.ExecutionConfig
 import org.scalatest.Inspectors
@@ -217,6 +193,12 @@ class SerializerTest extends AnyFlatSpec with Matchers with Inspectors with Test
     val ser = implicitly[TypeInformation[UUID]].createSerializer(ec)
     roundtrip(ser, UUID.randomUUID())
   }
+
+  it should "serialize case class with private field" in {
+    val ser = implicitly[TypeInformation[PrivateField]].createSerializer(ec)
+    roundtrip(ser, PrivateField("abc"))
+  }
+
 }
 
 object SerializerTest {
@@ -282,4 +264,7 @@ object SerializerTest {
       case class NestedBottom(a: Option[String], b: Option[String])
     }
   }
+
+  case class PrivateField(private val a: String)
+
 }

--- a/modules/flink-2-api/src/main/scala-2/org/apache/flinkx/api/LowPrioImplicits.scala
+++ b/modules/flink-2-api/src/main/scala-2/org/apache/flinkx/api/LowPrioImplicits.scala
@@ -5,8 +5,8 @@ import org.apache.flink.api.common.serialization.SerializerConfig
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flinkx.api.serializer.{CoproductSerializer, CaseClassSerializer, ScalaCaseObjectSerializer}
 import org.apache.flinkx.api.typeinfo.{CoproductTypeInformation, ProductTypeInformation}
+import org.apache.flinkx.api.util.ClassUtil.isFieldFinal
 
-import java.lang.reflect.{Field, Modifier}
 import scala.collection.mutable
 import scala.language.experimental.macros
 import scala.reflect._
@@ -65,15 +65,6 @@ private[api] trait LowPrioImplicits {
   }
 
   private def typeName[T: TypeTag]: String = typeOf[T].toString
-
-  private def isFieldFinal(fields: Array[Field], className: String, fieldName: String): Boolean =
-    Modifier.isFinal(
-      fields
-        .find(f => f.getName == fieldName)
-        .orElse(fields.find(f => f.getName == s"${className.replace('.', '$')}$$$$$fieldName"))
-        .getOrElse(throw new NoSuchFieldException(fieldName)) // Same as Class.getDeclaredField
-        .getModifiers
-    )
 
   implicit def deriveTypeInformation[T]: TypeInformation[T] = macro Magnolia.gen[T]
 }

--- a/modules/flink-2-api/src/main/scala-3/org/apache/flinkx/api/LowPrioImplicits.scala
+++ b/modules/flink-2-api/src/main/scala-3/org/apache/flinkx/api/LowPrioImplicits.scala
@@ -1,6 +1,5 @@
 package org.apache.flinkx.api
 
-import java.lang.reflect.{Field, Modifier}
 import scala.collection.mutable
 import scala.compiletime.summonInline
 import scala.deriving.Mirror
@@ -10,9 +9,9 @@ import magnolia1.{CaseClass, SealedTrait}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.TypeSerializer
 import org.apache.flink.api.common.serialization.SerializerConfig
-
 import org.apache.flinkx.api.serializer.{CoproductSerializer, CaseClassSerializer, ScalaCaseObjectSerializer}
 import org.apache.flinkx.api.typeinfo.{CoproductTypeInformation, ProductTypeInformation}
+import org.apache.flinkx.api.util.ClassUtil.isFieldFinal
 
 private[api] trait LowPrioImplicits extends TaggedDerivation[TypeInformation]:
   type Typeclass[T] = TypeInformation[T]
@@ -73,15 +72,6 @@ private[api] trait LowPrioImplicits extends TaggedDerivation[TypeInformation]:
         val ti    = new CoproductTypeInformation[T](clazz, serializer)
         if useCache then cache.put(cacheKey, ti)
         ti
-
-  private def isFieldFinal(fields: Array[Field], className: String, fieldName: String): Boolean =
-    Modifier.isFinal(
-      fields
-        .find(f => f.getName == fieldName)
-        .orElse(fields.find(f => f.getName == s"${className.replace('.', '$')}$$$$$fieldName"))
-        .getOrElse(throw new NoSuchFieldException(fieldName)) // Same as Class.getDeclaredField
-        .getModifiers
-    )
 
   final inline implicit def deriveTypeInformation[T](implicit
       m: Mirror.Of[T],

--- a/modules/flink-common-api/src/main/scala/org/apache/flinkx/api/util/ClassUtil.scala
+++ b/modules/flink-common-api/src/main/scala/org/apache/flinkx/api/util/ClassUtil.scala
@@ -1,0 +1,16 @@
+package org.apache.flinkx.api.util
+
+import java.lang.reflect.{Field, Modifier}
+
+object ClassUtil {
+
+  def isFieldFinal(fields: Array[Field], className: String, fieldName: String): Boolean =
+    Modifier.isFinal(
+      fields
+        .find(f => f.getName == fieldName)
+        .orElse(fields.find(f => f.getName == s"${className.replace('.', '$')}$$$$$fieldName"))
+        .getOrElse(throw new NoSuchFieldException(fieldName)) // Same as Class.getDeclaredField
+        .getModifiers
+    )
+
+}

--- a/modules/flink-common-api/src/test/scala/org/apache/flinkx/api/util/ClassUtilTest.scala
+++ b/modules/flink-common-api/src/test/scala/org/apache/flinkx/api/util/ClassUtilTest.scala
@@ -1,0 +1,61 @@
+package org.apache.flinkx.api.util
+
+import org.apache.flinkx.api.util.ClassUtilTest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ClassUtilTest extends AnyFlatSpec with Matchers {
+
+  it should "return true when the field is a val" in {
+    val aFinal = classOf[Final]
+    ClassUtil.isFieldFinal(aFinal.getDeclaredFields, aFinal.getName, "a") shouldBe true
+  }
+
+  it should "return false when the field is a var" in {
+    val aNonFinal = classOf[NonFinal]
+    ClassUtil.isFieldFinal(aNonFinal.getDeclaredFields, aNonFinal.getName, "a") shouldBe false
+  }
+
+  it should "return true when the field is a private val" in {
+    val aPrivateFinal = classOf[PrivateFinal]
+    ClassUtil.isFieldFinal(aPrivateFinal.getDeclaredFields, aPrivateFinal.getName, "a") shouldBe true
+  }
+
+  it should "return false when the field is a private var" in {
+    val aPrivateNonFinal = classOf[PrivateNonFinal]
+    ClassUtil.isFieldFinal(aPrivateNonFinal.getDeclaredFields, aPrivateNonFinal.getName, "a") shouldBe false
+  }
+
+  it should "return true when the field is a disrupted private val" in {
+    val aDisruptedPrivateFinal = classOf[DisruptedPrivateFinal]
+    ClassUtil.isFieldFinal(aDisruptedPrivateFinal.getDeclaredFields, aDisruptedPrivateFinal.getName, "a") shouldBe true
+  }
+
+  it should "return false when the field is a disrupted private var" in {
+    val aDisruptedPrivateNonFinal = classOf[DisruptedPrivateNonFinal]
+    ClassUtil.isFieldFinal(aDisruptedPrivateNonFinal.getDeclaredFields, aDisruptedPrivateNonFinal.getName, "a") shouldBe false
+  }
+
+  it should "throw NoSuchFieldException when the field doesn't exist" in {
+    val aFinal = classOf[Final]
+    assertThrows[NoSuchFieldException] {
+      ClassUtil.isFieldFinal(aFinal.getDeclaredFields, aFinal.getName, "wrongField") shouldBe true
+    }
+  }
+
+}
+
+object ClassUtilTest {
+
+  case class Final(a: String)
+  case class NonFinal(var a: String)
+  case class PrivateFinal(private val a: String)
+  case class PrivateNonFinal(private var a: String)
+  object DisruptiveObject {
+    def apply(value: Int): DisruptedPrivateFinal = DisruptedPrivateFinal(String.valueOf(value))
+    def apply(value: Long): DisruptedPrivateNonFinal = DisruptedPrivateNonFinal(String.valueOf(value))
+  }
+  case class DisruptedPrivateFinal(private val a: String)
+  case class DisruptedPrivateNonFinal(private var a: String)
+}
+


### PR DESCRIPTION
Hi @novakov-alexey,

As I said in this comment https://github.com/flink-extended/flink-scala-api/pull/248#discussion_r2077745972 I found a bug in the detection of the immutability of a case class with private field.

Under some circonstances (I'm not 100% sure) for exemple when a case class with private field is declared after an object, the field name in the java class takes the name `className$$fieldName` instead of the field name only.

The fix complexifies the field lookup to also handle this case.