### PR TITLE
Improve reliability of TypeInformation.createSerializer() and TypeSerializer.duplicate()

### DIFF
--- a/modules/flink-1-api/src/main/scala/org/apache/flinkx/api/serializer/ArraySerializer.scala
+++ b/modules/flink-1-api/src/main/scala/org/apache/flinkx/api/serializer/ArraySerializer.scala
@@ -29,6 +29,15 @@ class ArraySerializer[T](val child: TypeSerializer[T], clazz: Class[T]) extends 
     }
   }
 
+  override def duplicate(): ArraySerializer[T] = {
+    val duplicatedChild = child.duplicate()
+    if (duplicatedChild.eq(child)) {
+      this
+    } else {
+      new ArraySerializer[T](duplicatedChild, clazz)
+    }
+  }
+
   override def getLength: Int = -1
 
   override def deserialize(source: DataInputView): Array[T] = {

--- a/modules/flink-1-api/src/main/scala/org/apache/flinkx/api/serializer/ListCCSerializer.scala
+++ b/modules/flink-1-api/src/main/scala/org/apache/flinkx/api/serializer/ListCCSerializer.scala
@@ -16,6 +16,15 @@ class ListCCSerializer[T](child: TypeSerializer[T], clazz: Class[T]) extends Mut
     }
   }
 
+  override def duplicate(): ListCCSerializer[T] = {
+    val duplicatedChild = child.duplicate()
+    if (duplicatedChild.eq(child)) {
+      this
+    } else {
+      new ListCCSerializer[T](duplicatedChild, clazz)
+    }
+  }
+
   override def createInstance(): ::[T] = throw new IllegalArgumentException("cannot create instance of non-empty list")
   override def getLength: Int          = -1
   override def deserialize(source: DataInputView): ::[T] = {

--- a/modules/flink-1-api/src/main/scala/org/apache/flinkx/api/serializer/ListSerializer.scala
+++ b/modules/flink-1-api/src/main/scala/org/apache/flinkx/api/serializer/ListSerializer.scala
@@ -15,6 +15,15 @@ class ListSerializer[T](child: TypeSerializer[T], clazz: Class[T]) extends Mutab
     }
   }
 
+  override def duplicate(): ListSerializer[T] = {
+    val duplicatedChild = child.duplicate()
+    if (duplicatedChild.eq(child)) {
+      this
+    } else {
+      new ListSerializer[T](duplicatedChild, clazz)
+    }
+  }
+
   override def createInstance(): List[T] = List.empty[T]
   override def getLength: Int            = -1
   override def deserialize(source: DataInputView): List[T] = {

--- a/modules/flink-1-api/src/main/scala/org/apache/flinkx/api/serializer/SeqSerializer.scala
+++ b/modules/flink-1-api/src/main/scala/org/apache/flinkx/api/serializer/SeqSerializer.scala
@@ -15,6 +15,15 @@ class SeqSerializer[T](child: TypeSerializer[T], clazz: Class[T]) extends Mutabl
     }
   }
 
+  override def duplicate(): SeqSerializer[T] = {
+    val duplicatedChild = child.duplicate()
+    if (duplicatedChild.eq(child)) {
+      this
+    } else {
+      new SeqSerializer[T](duplicatedChild, clazz)
+    }
+  }
+
   override def createInstance(): Seq[T] = Seq.empty[T]
   override def getLength: Int           = -1
   override def deserialize(source: DataInputView): Seq[T] = {

--- a/modules/flink-1-api/src/main/scala/org/apache/flinkx/api/serializer/SetSerializer.scala
+++ b/modules/flink-1-api/src/main/scala/org/apache/flinkx/api/serializer/SetSerializer.scala
@@ -15,6 +15,15 @@ class SetSerializer[T](child: TypeSerializer[T], clazz: Class[T]) extends Mutabl
     }
   }
 
+  override def duplicate(): SetSerializer[T] = {
+    val duplicatedChild = child.duplicate()
+    if (duplicatedChild.eq(child)) {
+      this
+    } else {
+      new SetSerializer[T](duplicatedChild, clazz)
+    }
+  }
+
   override def createInstance(): Set[T] = Set.empty[T]
   override def getLength: Int           = -1
   override def deserialize(source: DataInputView): Set[T] = {

--- a/modules/flink-1-api/src/main/scala/org/apache/flinkx/api/serializer/VectorSerializer.scala
+++ b/modules/flink-1-api/src/main/scala/org/apache/flinkx/api/serializer/VectorSerializer.scala
@@ -15,6 +15,15 @@ class VectorSerializer[T](child: TypeSerializer[T], clazz: Class[T]) extends Mut
     }
   }
 
+  override def duplicate(): VectorSerializer[T] = {
+    val duplicatedChild = child.duplicate()
+    if (duplicatedChild.eq(child)) {
+      this
+    } else {
+      new VectorSerializer[T](duplicatedChild, clazz)
+    }
+  }
+
   override def createInstance(): Vector[T] = Vector.empty[T]
   override def getLength: Int              = -1
   override def deserialize(source: DataInputView): Vector[T] = {

--- a/modules/flink-1-api/src/main/scala/org/apache/flinkx/api/typeinfo/CollectionTypeInformation.scala
+++ b/modules/flink-1-api/src/main/scala/org/apache/flinkx/api/typeinfo/CollectionTypeInformation.scala
@@ -9,8 +9,7 @@ import scala.reflect.{ClassTag, classTag}
 case class CollectionTypeInformation[T: ClassTag](serializer: TypeSerializer[T]) extends TypeInformation[T] {
   val clazz = classTag[T].runtimeClass.asInstanceOf[Class[T]]
   override def createSerializer(config: ExecutionConfig): TypeSerializer[T] =
-    if (serializer.isImmutableType) serializer
-    else serializer.duplicate()
+    serializer.duplicate()
   override def isBasicType: Boolean   = false
   override def isTupleType: Boolean   = false
   override def isKeyType: Boolean     = false

--- a/modules/flink-1-api/src/main/scala/org/apache/flinkx/api/typeinfo/CoproductTypeInformation.scala
+++ b/modules/flink-1-api/src/main/scala/org/apache/flinkx/api/typeinfo/CoproductTypeInformation.scala
@@ -6,8 +6,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer
 
 case class CoproductTypeInformation[T](c: Class[T], ser: TypeSerializer[T]) extends TypeInformation[T] {
   override def createSerializer(config: ExecutionConfig): TypeSerializer[T] =
-    if (ser.isImmutableType) ser
-    else ser.duplicate()
+    ser.duplicate()
   override def isBasicType: Boolean   = false
   override def isTupleType: Boolean   = false
   override def isKeyType: Boolean     = false

--- a/modules/flink-1-api/src/main/scala/org/apache/flinkx/api/typeinfo/ProductTypeInformation.scala
+++ b/modules/flink-1-api/src/main/scala/org/apache/flinkx/api/typeinfo/ProductTypeInformation.scala
@@ -15,7 +15,6 @@ class ProductTypeInformation[T <: Product](
       fieldTypes,
       fieldNames
     ) {
-  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] =
-    if (ser.isImmutableType) ser
-    else ser.duplicate()
+  override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = ser.duplicate()
+
 }

--- a/modules/flink-1-api/src/main/scala/org/apache/flinkx/api/typeinfo/SimpleTypeInformation.scala
+++ b/modules/flink-1-api/src/main/scala/org/apache/flinkx/api/typeinfo/SimpleTypeInformation.scala
@@ -9,8 +9,7 @@ import scala.reflect.{classTag, ClassTag}
 abstract class SimpleTypeInformation[T: ClassTag: TypeSerializer] extends TypeInformation[T] {
   override def createSerializer(config: ExecutionConfig): TypeSerializer[T] = {
     val ser = implicitly[TypeSerializer[T]]
-    if (ser.isImmutableType) ser
-    else ser.duplicate()
+    ser.duplicate()
   }
   override def isBasicType: Boolean   = false
   override def isTupleType: Boolean   = false

--- a/modules/flink-1-api/src/test/scala/org/apache/flinkx/api/serializer/ArraySerializerTest.scala
+++ b/modules/flink-1-api/src/test/scala/org/apache/flinkx/api/serializer/ArraySerializerTest.scala
@@ -1,5 +1,7 @@
 package org.apache.flinkx.api.serializer
 
+import org.apache.flink.api.java.typeutils.runtime.RowSerializer
+import org.apache.flink.types.Row
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -24,6 +26,22 @@ class ArraySerializerTest extends AnyFlatSpec with Matchers {
     resultData(0) shouldNot be theSameInstanceAs expectedData(0)
     resultData(1) shouldNot be theSameInstanceAs expectedData(1)
     resultData shouldEqual expectedData
+  }
+
+  it should "return itself when duplicate an immutable serializer" in {
+    val intArraySerializer = new ArraySerializer[Int](org.apache.flinkx.api.serializers.intSerializer, classOf[Int])
+
+    val duplicatedIntArraySerializer = intArraySerializer.duplicate()
+    duplicatedIntArraySerializer should be theSameInstanceAs intArraySerializer
+  }
+
+  it should "duplicate itself when the serializer is mutable" in {
+    val rowArraySerializer = new ArraySerializer[Row](new RowSerializer(Array.empty), classOf[Row])
+
+    val duplicatedIntArraySerializer = rowArraySerializer.duplicate()
+
+    duplicatedIntArraySerializer shouldNot be theSameInstanceAs rowArraySerializer
+    duplicatedIntArraySerializer should be (rowArraySerializer)
   }
 
 }

--- a/modules/flink-1-api/src/test/scala/org/apache/flinkx/api/serializer/CoproductSerializerTest.scala
+++ b/modules/flink-1-api/src/test/scala/org/apache/flinkx/api/serializer/CoproductSerializerTest.scala
@@ -1,21 +1,34 @@
 package org.apache.flinkx.api.serializer
 
 import org.apache.flink.api.common.typeutils.TypeSerializer
-import org.apache.flinkx.api.serializer.CoproductSerializerTest.{Immutable, Immutable2, Immutable3, Mutable, Mutable1}
-import org.apache.flinkx.api.serializers._
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.types.Row
+import org.apache.flinkx.api.serializer.CoproductSerializerTest.*
+import org.apache.flinkx.api.serializers.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class CoproductSerializerTest extends AnyFlatSpec with Matchers {
 
-  it should "be immutable when all subtypes of the sealed trait are immutable" in {
+  "isImmutableType" should "be true when all subtypes of the sealed trait are immutable" in {
     val immutableSerializer = implicitly[TypeSerializer[Immutable]]
     immutableSerializer.isImmutableType shouldEqual true
   }
 
-  it should "be mutable when one subtype of the sealed trait is mutable" in {
+  it should "be false when one subtype of the sealed trait is mutable" in {
     val mutableSerializer = implicitly[TypeSerializer[Mutable]]
     mutableSerializer.isImmutableType shouldEqual false
+  }
+
+  "isImmutableSerializer" should "be true when all sub-serializers of the sealed trait are immutable" in {
+    val immutableSerializer = implicitly[TypeSerializer[Immutable]]
+    immutableSerializer.asInstanceOf[CoproductSerializer[Immutable]].isImmutableSerializer shouldEqual true
+  }
+
+  it should "be false when one sub-serializer of the sealed trait is mutable" in {
+    implicit val rowInfo: RowTypeInfo = new RowTypeInfo()
+    val mutableSerializer             = implicitly[TypeSerializer[MutableSerializer]]
+    mutableSerializer.asInstanceOf[CoproductSerializer[MutableSerializer]].isImmutableSerializer shouldEqual false
   }
 
   "copy" should "return null when the given object is null" in {
@@ -26,7 +39,7 @@ class CoproductSerializerTest extends AnyFlatSpec with Matchers {
     resultData shouldEqual null
   }
 
-  it should "return the same instance when immutable" in {
+  it should "return the same instance when the data is immutable" in {
     val immutableSerializer = implicitly[TypeSerializer[Immutable]]
     val expectedData        = Immutable2("a")
 
@@ -35,7 +48,7 @@ class CoproductSerializerTest extends AnyFlatSpec with Matchers {
     resultData should be theSameInstanceAs expectedData
   }
 
-  it should "copy the instance when mutable" in {
+  it should "copy the instance when the data is mutable" in {
     val mutableSerializer = implicitly[TypeSerializer[Mutable]]
     val expectedData      = Mutable1("a")
 
@@ -54,6 +67,24 @@ class CoproductSerializerTest extends AnyFlatSpec with Matchers {
     resultData should be theSameInstanceAs expectedData
   }
 
+  "duplicate" should "return itself when the serializer is immutable" in {
+    val immutableSerializer = implicitly[TypeSerializer[Mutable]]
+
+    val duplicatedSerializer = immutableSerializer.duplicate()
+
+    duplicatedSerializer should be theSameInstanceAs immutableSerializer
+  }
+
+  it should "return a new instance of itself when the serializer is mutable" in {
+    implicit val rowInfo: RowTypeInfo = new RowTypeInfo()
+    val serializer = implicitly[TypeSerializer[MutableSerializer]]
+
+    val duplicatedSerializer = serializer.duplicate()
+
+    duplicatedSerializer shouldNot be theSameInstanceAs serializer
+    duplicatedSerializer should be(serializer)
+  }
+
 }
 
 object CoproductSerializerTest {
@@ -67,5 +98,10 @@ object CoproductSerializerTest {
 
   case class Immutable3(a: String)   extends Mutable
   case class Mutable1(var a: String) extends Mutable
+
+  sealed trait MutableSerializer
+
+  case class Immutable4(a: String)      extends MutableSerializer
+  case class MutableSerializer1(a: Row) extends MutableSerializer
 
 }

--- a/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/serializer/ArraySerializer.scala
+++ b/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/serializer/ArraySerializer.scala
@@ -29,6 +29,15 @@ class ArraySerializer[T](val child: TypeSerializer[T], clazz: Class[T]) extends 
     }
   }
 
+  override def duplicate(): ArraySerializer[T] = {
+    val duplicatedChild = child.duplicate()
+    if (duplicatedChild.eq(child)) {
+      this
+    } else {
+      new ArraySerializer[T](duplicatedChild, clazz)
+    }
+  }
+
   override def getLength: Int = -1
 
   override def deserialize(source: DataInputView): Array[T] = {

--- a/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/serializer/ListCCSerializer.scala
+++ b/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/serializer/ListCCSerializer.scala
@@ -16,6 +16,15 @@ class ListCCSerializer[T](child: TypeSerializer[T], clazz: Class[T]) extends Mut
     }
   }
 
+  override def duplicate(): ListCCSerializer[T] = {
+    val duplicatedChild = child.duplicate()
+    if (duplicatedChild.eq(child)) {
+      this
+    } else {
+      new ListCCSerializer[T](duplicatedChild, clazz)
+    }
+  }
+
   override def createInstance(): ::[T] = throw new IllegalArgumentException("cannot create instance of non-empty list")
   override def getLength: Int          = -1
   override def deserialize(source: DataInputView): ::[T] = {

--- a/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/serializer/ListSerializer.scala
+++ b/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/serializer/ListSerializer.scala
@@ -15,6 +15,15 @@ class ListSerializer[T](child: TypeSerializer[T], clazz: Class[T]) extends Mutab
     }
   }
 
+  override def duplicate(): ListSerializer[T] = {
+    val duplicatedChild = child.duplicate()
+    if (duplicatedChild.eq(child)) {
+      this
+    } else {
+      new ListSerializer[T](duplicatedChild, clazz)
+    }
+  }
+
   override def createInstance(): List[T] = List.empty[T]
   override def getLength: Int            = -1
   override def deserialize(source: DataInputView): List[T] = {

--- a/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/serializer/MapSerializer.scala
+++ b/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/serializer/MapSerializer.scala
@@ -16,6 +16,16 @@ class MapSerializer[K, V](ks: TypeSerializer[K], vs: TypeSerializer[V]) extends 
     }
   }
 
+  override def duplicate(): MapSerializer[K, V] = {
+    val duplicatedKS = ks.duplicate()
+    val duplicatedVS = vs.duplicate()
+    if (duplicatedKS.eq(ks) && duplicatedVS.eq(vs)) {
+      this
+    } else {
+      new MapSerializer[K, V](duplicatedKS, duplicatedVS)
+    }
+  }
+
   override def createInstance(): Map[K, V] = Map.empty[K, V]
   override def getLength: Int              = -1
   override def deserialize(source: DataInputView): Map[K, V] = {

--- a/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/serializer/MappedSerializer.scala
+++ b/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/serializer/MappedSerializer.scala
@@ -17,6 +17,16 @@ case class MappedSerializer[A, B](mapper: TypeMapper[A, B], ser: TypeSerializer[
     }
   }
 
+  override def duplicate(): MappedSerializer[A, B] = {
+    val duplicatedSer = ser.duplicate()
+    if (duplicatedSer.eq(ser)) {
+      this
+    } else {
+      MappedSerializer[A, B](mapper, duplicatedSer)
+    }
+  }
+
+
   override def equals(other: Any): Boolean = other match {
     case that: MappedSerializer[_, _] =>
         mapper == that.mapper &&

--- a/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/serializer/SeqSerializer.scala
+++ b/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/serializer/SeqSerializer.scala
@@ -15,6 +15,15 @@ class SeqSerializer[T](child: TypeSerializer[T], clazz: Class[T]) extends Mutabl
     }
   }
 
+  override def duplicate(): SeqSerializer[T] = {
+    val duplicatedChild = child.duplicate()
+    if (duplicatedChild.eq(child)) {
+      this
+    } else {
+      new SeqSerializer[T](duplicatedChild, clazz)
+    }
+  }
+
   override def createInstance(): Seq[T] = Seq.empty[T]
   override def getLength: Int           = -1
   override def deserialize(source: DataInputView): Seq[T] = {

--- a/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/serializer/SetSerializer.scala
+++ b/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/serializer/SetSerializer.scala
@@ -15,6 +15,15 @@ class SetSerializer[T](child: TypeSerializer[T], clazz: Class[T]) extends Mutabl
     }
   }
 
+  override def duplicate(): SetSerializer[T] = {
+    val duplicatedChild = child.duplicate()
+    if (duplicatedChild.eq(child)) {
+      this
+    } else {
+      new SetSerializer[T](duplicatedChild, clazz)
+    }
+  }
+
   override def createInstance(): Set[T] = Set.empty[T]
   override def getLength: Int           = -1
   override def deserialize(source: DataInputView): Set[T] = {

--- a/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/serializer/VectorSerializer.scala
+++ b/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/serializer/VectorSerializer.scala
@@ -15,6 +15,15 @@ class VectorSerializer[T](child: TypeSerializer[T], clazz: Class[T]) extends Mut
     }
   }
 
+  override def duplicate(): VectorSerializer[T] = {
+    val duplicatedChild = child.duplicate()
+    if (duplicatedChild.eq(child)) {
+      this
+    } else {
+      new VectorSerializer[T](duplicatedChild, clazz)
+    }
+  }
+
   override def createInstance(): Vector[T] = Vector.empty[T]
   override def getLength: Int              = -1
   override def deserialize(source: DataInputView): Vector[T] = {

--- a/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/typeinfo/CollectionTypeInformation.scala
+++ b/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/typeinfo/CollectionTypeInformation.scala
@@ -9,8 +9,7 @@ import scala.reflect.{ClassTag, classTag}
 case class CollectionTypeInformation[T: ClassTag](serializer: TypeSerializer[T]) extends TypeInformation[T] {
   val clazz = classTag[T].runtimeClass.asInstanceOf[Class[T]]
   override def createSerializer(config: SerializerConfig): TypeSerializer[T] =
-    if (serializer.isImmutableType) serializer
-    else serializer.duplicate()
+    serializer.duplicate()
   override def isBasicType: Boolean   = false
   override def isTupleType: Boolean   = false
   override def isKeyType: Boolean     = false

--- a/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/typeinfo/CoproductTypeInformation.scala
+++ b/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/typeinfo/CoproductTypeInformation.scala
@@ -6,8 +6,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer
 
 case class CoproductTypeInformation[T](c: Class[T], ser: TypeSerializer[T]) extends TypeInformation[T] {
   override def createSerializer(config: SerializerConfig): TypeSerializer[T] =
-    if (ser.isImmutableType) ser
-    else ser.duplicate()
+    ser.duplicate()
   override def isBasicType: Boolean   = false
   override def isTupleType: Boolean   = false
   override def isKeyType: Boolean     = false

--- a/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/typeinfo/ProductTypeInformation.scala
+++ b/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/typeinfo/ProductTypeInformation.scala
@@ -15,7 +15,6 @@ class ProductTypeInformation[T <: Product](
       fieldTypes,
       fieldNames
     ) {
-  override def createSerializer(config: SerializerConfig): TypeSerializer[T] =
-    if (ser.isImmutableType) ser
-    else ser.duplicate()
+  override def createSerializer(config: SerializerConfig): TypeSerializer[T] = ser.duplicate()
+
 }

--- a/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/typeinfo/SimpleTypeInformation.scala
+++ b/modules/flink-2-api/src/main/scala/org/apache/flinkx/api/typeinfo/SimpleTypeInformation.scala
@@ -9,8 +9,7 @@ import scala.reflect.{classTag, ClassTag}
 abstract class SimpleTypeInformation[T: ClassTag: TypeSerializer] extends TypeInformation[T] {
   override def createSerializer(config: SerializerConfig): TypeSerializer[T] = {
     val ser = implicitly[TypeSerializer[T]]
-    if (ser.isImmutableType) ser
-    else ser.duplicate()
+    ser.duplicate()
   }
   override def isBasicType: Boolean   = false
   override def isTupleType: Boolean   = false

--- a/modules/flink-common-api/src/test/scala/org/apache/flinkx/api/serializer/CaseClassSerializerTest.scala
+++ b/modules/flink-common-api/src/test/scala/org/apache/flinkx/api/serializer/CaseClassSerializerTest.scala
@@ -1,31 +1,42 @@
 package org.apache.flinkx.api.serializer
 
 import org.apache.flink.api.common.typeutils.base.StringSerializer
+import org.apache.flink.api.java.typeutils.runtime.RowSerializer
 import org.apache.flinkx.api.serializer.CaseClassSerializerTest.{Immutable, Mutable, OuterImmutable, OuterMutable}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class CaseClassSerializerTest extends AnyFlatSpec with Matchers {
 
-  it should "be immutable when parameters are immutable" in {
+  "isImmutableType" should "be true when parameters are immutable" in {
     val serializer = new CaseClassSerializer[Immutable](classOf[Immutable], Array(StringSerializer.INSTANCE), true)
     serializer.isImmutableType should be(true)
   }
 
-  it should "be mutable when one parameter is mutable" in {
+  it should "be false when one parameter is mutable" in {
     val serializer = new CaseClassSerializer[Mutable](classOf[Mutable], Array(StringSerializer.INSTANCE), false)
     serializer.isImmutableType should be(false)
   }
 
-  it should "be mutable when the content of one parameter is mutable" in {
+  it should "be false when the content of one parameter is mutable" in {
     val mutableSerializer = new CaseClassSerializer[Mutable](classOf[Mutable], Array(StringSerializer.INSTANCE), false)
     val serializer = new CaseClassSerializer[OuterImmutable](classOf[OuterImmutable], Array(mutableSerializer), true)
     mutableSerializer.isImmutableType should be(false)
   }
 
-  it should "be mutable when missing information about one parameter" in {
+  it should "be false when missing information about one parameter" in {
     val serializer = new CaseClassSerializer[Immutable](classOf[Immutable], Array(null), true)
     serializer.isImmutableType should be(false)
+  }
+
+  "isImmutableSerializer" should "be true when sub-serializers are immutable" in {
+    val serializer = new CaseClassSerializer[Immutable](classOf[Immutable], Array(StringSerializer.INSTANCE), true)
+    serializer.isImmutableSerializer should be(true)
+  }
+
+  it should "be false when one sub-serializer is mutable" in {
+    val serializer = new CaseClassSerializer[Immutable](classOf[Immutable], Array(new RowSerializer(Array.empty)), true)
+    serializer.isImmutableSerializer should be(false)
   }
 
   "copy" should "return the same case class when immutable" in {
@@ -82,6 +93,18 @@ class CaseClassSerializerTest extends AnyFlatSpec with Matchers {
     resultData shouldNot be theSameInstanceAs expectedData
     resultData.a should be theSameInstanceAs expectedData.a
     resultData shouldEqual expectedData
+  }
+
+  "duplicate" should "return itself when the serializer is immutable" in {
+    val serializer = new CaseClassSerializer[Mutable](classOf[Mutable], Array(StringSerializer.INSTANCE), false)
+    serializer.duplicate() should be theSameInstanceAs serializer
+  }
+
+  it should "return a new instance of itself when the serializer is mutable" in {
+    val serializer = new CaseClassSerializer[Mutable](classOf[Mutable], Array(new RowSerializer(Array.empty)), false)
+    val duplicatedSerializer = serializer.duplicate()
+    duplicatedSerializer shouldNot be theSameInstanceAs serializer
+    duplicatedSerializer should be(serializer)
   }
 
 }


### PR DESCRIPTION
Hi @novakov-alexey,

Another PR to safeguard the serializers. I have not encountered a bug, but I think there is a potential problem with implementations of `TypeInformation.createSerializer()` and `TypeSerializer.duplicate()` if the serializer itself or one of its sub-serializers is mutable, things can escalate quickly into weird bugs because the doc of `duplicate()` says it guarantees the isolation of serializers between threads.

This PR fixes two problems:
- Several implementations of `TypeInformation.createSerializer()` uses `TypeSerializer.isImmutableType` to choose between returning itself or make a copy. `isImmutableType` is about the immutability of the data, whereas the information we need is the immutability of the serializer itself. There is no other solution than to always call `duplicate()`.
- Most of the serializers delegate the implementation of `duplicate()` to `TypeSerializerSingleton.duplicate()` which always returns itself without checking if the serializer is immutable or not. Because there is no `isImmutableSerializer` function available in the API, we have to call `duplicate()` on sub-serializers, check the equality between the original and the duplicated and if they are equal we can deduce the sub-serializer is immutable.

There should have no performance downgrade because, either the call to `duplicate()` on sub-serializer is cheap on immutable serializer, or it will be necessary anyway for the duplication of a mutable serializer, there is no waste on duplicate. But to ensure there is no performance issue, I precomputed an `isImmutableSerializer` flag on case class and sealed trait serializers.