### PR TITLE
feature: handle null field in case class

### DIFF
--- a/modules/flink-1-api/src/main/scala-3/org/apache/flinkx/api/LowPrioImplicits.scala
+++ b/modules/flink-1-api/src/main/scala-3/org/apache/flinkx/api/LowPrioImplicits.scala
@@ -8,7 +8,8 @@ import magnolia1.{CaseClass, SealedTrait}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.TypeSerializer
 import org.apache.flink.api.common.ExecutionConfig
-import org.apache.flinkx.api.serializer.{CaseClassSerializer, CoproductSerializer, ScalaCaseObjectSerializer}
+import org.apache.flink.api.java.typeutils.runtime.NullableSerializer
+import org.apache.flinkx.api.serializer.{CaseClassSerializer, CoproductSerializer, ScalaCaseObjectSerializer, nullable}
 import org.apache.flinkx.api.typeinfo.{CoproductTypeInformation, ProductTypeInformation}
 import org.apache.flinkx.api.util.ClassUtil.isCaseClassImmutable
 
@@ -38,8 +39,12 @@ private[api] trait LowPrioImplicits extends TaggedDerivation[TypeInformation]:
           else
             new CaseClassSerializer[T & Product](
               clazz = clazz,
-              scalaFieldSerializers =
-                IArray.genericWrapArray(ctx.params.map(_.typeclass.createSerializer(config))).toArray,
+              scalaFieldSerializers = IArray.genericWrapArray(ctx.params.map { p =>
+                val ser = p.typeclass.createSerializer(config)
+                if (p.annotations.exists(_.isInstanceOf[nullable])) {
+                  NullableSerializer.wrapIfNullIsNotSupported(ser, true)
+                } else ser
+              }).toArray,
               isCaseClassImmutable = isCaseClassImmutable(clazz, ctx.params.map(_.label))
             )
         val ti = new ProductTypeInformation[T & Product](

--- a/modules/flink-1-api/src/test/scala/org/apache/flinkx/api/SchemaEvolutionTest.scala
+++ b/modules/flink-1-api/src/test/scala/org/apache/flinkx/api/SchemaEvolutionTest.scala
@@ -3,7 +3,7 @@ package org.apache.flinkx.api
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.core.memory._
-import org.apache.flinkx.api.SchemaEvolutionTest.{Click, ClickEvent, Event, View}
+import org.apache.flinkx.api.SchemaEvolutionTest.{Click, ClickEvent, Event}
 import org.apache.flinkx.api.serializer.CaseClassSerializer
 import org.apache.flinkx.api.serializers._
 import org.scalatest.flatspec.AnyFlatSpec
@@ -13,11 +13,9 @@ import java.io.ByteArrayOutputStream
 import java.nio.file.{Files, Path}
 
 class SchemaEvolutionTest extends AnyFlatSpec with Matchers {
-  private implicit val clickEventTypeInfo: TypeInformation[ClickEvent] = deriveTypeInformation[ClickEvent]
-  private implicit val viewInfo: TypeInformation[View]                 = deriveTypeInformation[View]
-  private implicit val newClickTypeInfo: TypeInformation[Click]        = deriveTypeInformation[Click]
-  private implicit val eventTypeInfo: TypeInformation[Event]           = deriveTypeInformation[Event]
-  private val clicks                                                   =
+  private implicit val newClickTypeInfo: TypeInformation[Click] = deriveTypeInformation[Click]
+  private implicit val eventTypeInfo: TypeInformation[Event]    = deriveTypeInformation[Event]
+  private val clicks                                            =
     List(ClickEvent("a", "2021-01-01"), ClickEvent("b", "2021-01-01"), ClickEvent("c", "2021-01-01"))
 
   def createSerializer[T: TypeInformation] =

--- a/modules/flink-1-api/src/test/scala/org/apache/flinkx/api/SerializerTest.scala
+++ b/modules/flink-1-api/src/test/scala/org/apache/flinkx/api/SerializerTest.scala
@@ -207,6 +207,11 @@ class SerializerTest extends AnyFlatSpec with Matchers with Inspectors with Test
     roundtrip(ser, ExtendingCaseClass("abc", "def"))
   }
 
+  it should "serialize a null case class" in {
+    val ser = implicitly[TypeInformation[Simple]].createSerializer(ec)
+    roundtrip(ser, null)
+  }
+
   it should "serialize a case class with nullable field" in {
     val ser = implicitly[TypeInformation[NullableField]].createSerializer(ec)
     roundtrip(ser, NullableField(null, Bar(1)))
@@ -224,6 +229,11 @@ class SerializerTest extends AnyFlatSpec with Matchers with Inspectors with Test
     // IntSerializer doesn't handle null so it's wrapped in a NullableSerializer
     ccser.getFieldSerializers()(0) shouldBe a[NullableSerializer[Integer]]
     ccser.getFieldSerializers()(1) shouldBe a[StringSerializer] // StringSerializer natively handles null
+  }
+
+  it should "serialize a case class with a nullable field of a fixed size case class" in {
+    val ser = implicitly[TypeInformation[NullableFixedSizeCaseClass]].createSerializer(ec)
+    roundtrip(ser, NullableFixedSizeCaseClass(null))
   }
 
 }
@@ -307,5 +317,7 @@ object SerializerTest {
   final case class NoArity()
 
   final case class NullableFieldWithNoArity(var a: NoArity)
+
+  final case class NullableFixedSizeCaseClass(@nullable javaTime: JavaTime)
 
 }

--- a/modules/flink-2-api/src/main/scala-2/org/apache/flinkx/api/LowPrioImplicits.scala
+++ b/modules/flink-2-api/src/main/scala-2/org/apache/flinkx/api/LowPrioImplicits.scala
@@ -3,7 +3,8 @@ package org.apache.flinkx.api
 import magnolia1.{CaseClass, Magnolia, SealedTrait}
 import org.apache.flink.api.common.serialization.SerializerConfig
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flinkx.api.serializer.{CoproductSerializer, CaseClassSerializer, ScalaCaseObjectSerializer}
+import org.apache.flink.api.java.typeutils.runtime.NullableSerializer
+import org.apache.flinkx.api.serializer.{CaseClassSerializer, CoproductSerializer, ScalaCaseObjectSerializer, nullable}
 import org.apache.flinkx.api.typeinfo.{CoproductTypeInformation, ProductTypeInformation}
 import org.apache.flinkx.api.util.ClassUtil.isCaseClassImmutable
 
@@ -32,7 +33,12 @@ private[api] trait LowPrioImplicits {
         } else {
           new CaseClassSerializer[T](
             clazz = clazz,
-            scalaFieldSerializers = ctx.parameters.map(_.typeclass.createSerializer(config)).toArray,
+            scalaFieldSerializers = ctx.parameters.map { p =>
+              val ser = p.typeclass.createSerializer(config)
+              if (p.annotations.exists(_.isInstanceOf[nullable])) {
+                NullableSerializer.wrapIfNullIsNotSupported(ser, true)
+              } else ser
+            }.toArray,
             isCaseClassImmutable = isCaseClassImmutable(clazz, ctx.parameters.map(_.label))
           )
         }

--- a/modules/flink-common-api/src/main/scala/org/apache/flinkx/api/serializer/CaseClassSerializer.scala
+++ b/modules/flink-common-api/src/main/scala/org/apache/flinkx/api/serializer/CaseClassSerializer.scala
@@ -92,6 +92,8 @@ class CaseClassSerializer[T <: Product](
       createInstance(fields.toArray)
     }
 
+  override val getLength: Int = if (super.getLength == -1) -1 else super.getLength + 4 // +4 bytes for the arity field
+
   def serialize(value: T, target: DataOutputView): Unit = {
     // Write an arity of -1 to indicate null value
     val sourceArity = if (value == null) -1 else arity

--- a/modules/flink-common-api/src/main/scala/org/apache/flinkx/api/serializer/nullable.scala
+++ b/modules/flink-common-api/src/main/scala/org/apache/flinkx/api/serializer/nullable.scala
@@ -1,0 +1,5 @@
+package org.apache.flinkx.api.serializer
+
+import scala.annotation.StaticAnnotation
+
+final class nullable extends StaticAnnotation


### PR DESCRIPTION
Hi @novakov-alexey,

As a complement for the previous PR (https://github.com/flink-extended/flink-scala-api/pull/265) to handle nullability (https://github.com/flink-extended/flink-scala-api/issues/264), I propose this PR to handle null fields in case class.

The idea is to allow a `@nullable` annotation on case class fields that is handled at case class serializer creation in `LowPrioImplicits.join()`.

It seems quite easy to implement thanks to improvement made in previous PR (it relies on changes in `ConstructorCompat`).

However, nullable field handling can be done in different ways:
- Create our own `@nullable` annotation (currently in this PR).
- Don't create `@nullable` annotation and always wrap fields in `NullableSerializer`.
- Accept external annotation like `javax.annotation.Nullable`, it's not in the JDK but is commonly used by Java libraries like Flink, Guava and Spring. It could be accepted alongside our annotation, and be an optional dependency.

I have no preferences over the 3 options, but I like the idea to give a semantic hint a field is meant to be nullable with an annotation. It is very common (at least in Java world) to use `@Nullable` annotation for this even it has no effect.