### PR TITLE
Scala 2: Recursive type info is not supported: fail-fast with a comprehensive message instead

### DIFF
--- a/modules/flink-common-api/src/main/scala/org/apache/flinkx/api/typeinfo/MarkerTypeInfo.scala
+++ b/modules/flink-common-api/src/main/scala/org/apache/flinkx/api/typeinfo/MarkerTypeInfo.scala
@@ -1,0 +1,24 @@
+package org.apache.flinkx.api.typeinfo
+
+import org.apache.flink.api.common.ExecutionConfig
+import org.apache.flink.api.common.serialization.SerializerConfig
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.common.typeutils.TypeSerializer
+
+case object MarkerTypeInfo extends TypeInformation[Nothing] {
+
+  override def createSerializer(config: SerializerConfig): TypeSerializer[Nothing] = null
+  // override modifier removed to satisfy both implementation requirement of Flink 1.x and removal in 2.x
+  def createSerializer(config: ExecutionConfig): TypeSerializer[Nothing] = null
+
+  override def isBasicType: Boolean         = false
+  override def isTupleType: Boolean         = false
+  override def isKeyType: Boolean           = false
+  override def getTotalFields: Int          = 1
+  override def getTypeClass: Class[Nothing] = classOf[Nothing]
+  override def getArity: Int                = 1
+  override def toString: String             = "MarkerTypeInfo"
+  override def equals(obj: Any): Boolean    = obj.isInstanceOf[MarkerTypeInfo.type]
+  override def hashCode(): Int              = 0
+
+}

--- a/modules/flink-common-api/src/test/scala-2/org/apache/flinkx/api/RecursiveTest.scala
+++ b/modules/flink-common-api/src/test/scala-2/org/apache/flinkx/api/RecursiveTest.scala
@@ -1,0 +1,24 @@
+package org.apache.flinkx.api
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.util.FlinkRuntimeException
+import org.apache.flinkx.api.RecursiveTest.Node
+import org.apache.flinkx.api.serializers._
+import org.scalatest.Inspectors
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class RecursiveTest extends AnyFlatSpec with Matchers with Inspectors with TestUtils {
+
+  it should "fail fast with a comprehensive message when the derivation is recursive" in {
+    val exception = intercept[FlinkRuntimeException](implicitly[TypeInformation[Node]])
+    exception.getMessage shouldBe "Unsupported: recursivity detected in 'org.apache.flinkx.api.RecursiveTest.Node'."
+  }
+
+}
+
+object RecursiveTest {
+
+  case class Node(left: Option[Node], right: Option[Node])
+
+}

--- a/modules/flink-common-api/src/test/scala/org/apache/flinkx/api/SerializerTest.scala
+++ b/modules/flink-common-api/src/test/scala/org/apache/flinkx/api/SerializerTest.scala
@@ -86,11 +86,6 @@ class SerializerTest extends AnyFlatSpec with Matchers with Inspectors with Test
     roundtrip(ser, Nil)
   }
 
-  it should "derive recursively" in {
-    // recursive is broken
-    // val ti = implicitly[TypeInformation[Node]]
-  }
-
   it should "derive list" in {
     val ser = implicitly[TypeInformation[List[Simple]]].createSerializer(ec)
     all(ser, List(Simple(1, "a")))
@@ -285,8 +280,6 @@ object SerializerTest {
   }
   case class P1(a: String) extends Param[String]
   case class P2(a: Int)    extends Param[Int]
-
-  case class Node(left: Option[Node], right: Option[Node])
 
   case class SimpleOption(a: Option[String])
 


### PR DESCRIPTION
Hi @novakov-alexey,

Here is a small PR to improve the error message when trying to create a type information on a recursive type. We encountered this case and thought the error could be easily detected and fail-fast with a comprehensive message instead of a stack overflow error like this:
```
java.lang.StackOverflowError
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$8.scala$reflect$runtime$SynchronizedSymbols$SynchronizedSymbol$$$outer(SynchronizedSymbols.scala:206)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$7.scala$reflect$runtime$SynchronizedSymbols$SynchronizedSymbol$$$outer(SynchronizedSymbols.scala:203)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.validTo(SynchronizedSymbols.scala:149)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.validTo$(SynchronizedSymbols.scala:157)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$7.validTo(SynchronizedSymbols.scala:203)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.$anonfun$typeParams$1(SynchronizedSymbols.scala:180)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.typeParams(SynchronizedSymbols.scala:149)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.typeParams$(SynchronizedSymbols.scala:165)
	at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$7.typeParams(SynchronizedSymbols.scala:203)
	at scala.reflect.internal.Types$NoArgsTypeRef.typeParams(Types.scala:2162)
	at scala.reflect.internal.Definitions$DefinitionsClass.fullyInitializeType(Definitions.scala:245)
	at scala.reflect.internal.Types$Type.toString(Types.scala:937)
	at org.apache.flinkx.api.LowPrioImplicits.typeName(LowPrioImplicits.scala:73)
	at org.apache.flinkx.api.LowPrioImplicits.join(LowPrioImplicits.scala:27)
	at org.apache.flinkx.api.LowPrioImplicits.join$(LowPrioImplicits.scala:24)
	at org.apache.flinkx.api.serializers$.join(serializers.scala:173)
	at org.apache.flinkx.api.RecursiveTypeInfoTest.nodeTypeclass$macro$1$lzycompute$1(RecursiveTypeInfoTest.scala:14)
	at org.apache.flinkx.api.RecursiveTypeInfoTest.nodeTypeclass$macro$1$1(RecursiveTypeInfoTest.scala:14)
	at org.apache.flinkx.api.RecursiveTypeInfoTest.paramTypeclass$macro$3$lzycompute$1(RecursiveTypeInfoTest.scala:14)
	at org.apache.flinkx.api.RecursiveTypeInfoTest.paramTypeclass$macro$3$1(RecursiveTypeInfoTest.scala:14)
	at org.apache.flinkx.api.RecursiveTypeInfoTest.$anonfun$new$2(RecursiveTypeInfoTest.scala:14)
	at magnolia1.CallByNeed.value$lzycompute(magnolia.scala:985)
	at magnolia1.CallByNeed.value(magnolia.scala:981)
	at magnolia1.Param$$anon$7.typeclass(interface.scala:330)
	at org.apache.flinkx.api.LowPrioImplicits.$anonfun$join$1(LowPrioImplicits.scala:38)
	at scala.collection.immutable.ArraySeq.map(ArraySeq.scala:75)
	at scala.collection.immutable.ArraySeq.map(ArraySeq.scala:35)
	at org.apache.flinkx.api.LowPrioImplicits.join(LowPrioImplicits.scala:37)
	at org.apache.flinkx.api.LowPrioImplicits.join$(LowPrioImplicits.scala:24)
	at org.apache.flinkx.api.serializers$.join(serializers.scala:173)
[...]
```

When I tried to reproduce the stack overflow error here, I saw this commented test in `SerializerTest` :
```
  it should "derive recursively" in {
    // recursive is broken
    // val ti = implicitly[TypeInformation[Node]]
  }
```
I thought recursive type derivation could be fixed. I managed to hack `LowPrioImplicits.join()` to work with recursive type but `CaseClassSerializer` doesn't support recursivity at every place it computes things iterating over its fields, at least:
- `TupleSerializerBase.getLength()`
- `isImmutableType`
  - `copy()`
- `isImmutableSerializer`
  - `CaseClassSerializer.duplicate()`
    - `CaseClassTypeInfo.createSerializer()`

It's a dead end, so the fail-fast solution seems the way to go. Here is the resulting message instead of the stack overflow error:
```
Unsupported: recursivity detected in 'org.apache.flinkx.api.RecursiveTest.Node'.
org.apache.flink.util.FlinkRuntimeException: Unsupported: recursivity detected in 'org.apache.flinkx.api.RecursiveTest.Node'.
	at org.apache.flinkx.api.LowPrioImplicits.join(LowPrioImplicits.scala:31)
```

Interestingly, Scala 3 detects the recursive type derivation problem at compile time, so this PR applies for Scala 2 only.