### PR TITLE
Handle Scala 3 enum & enum value

### DIFF
--- a/modules/flink-common-api/src/main/scala-3/org/apache/flinkx/api/TypeInformationDerivation.scala
+++ b/modules/flink-common-api/src/main/scala-3/org/apache/flinkx/api/TypeInformationDerivation.scala
@@ -16,7 +16,7 @@ import org.apache.flinkx.api.serializer.{
 import org.apache.flinkx.api.typeinfo.{CaseClassTypeInfo, CoproductTypeInformation}
 import org.apache.flinkx.api.util.ClassUtil.isCaseClassImmutable
 
-import scala.IArray.given
+import scala.IArray.genericWrapArray
 import scala.collection.mutable
 import scala.reflect.ClassTag
 

--- a/modules/flink-common-api/src/main/scala-3/org/apache/flinkx/api/TypeInformationDerivation.scala
+++ b/modules/flink-common-api/src/main/scala-3/org/apache/flinkx/api/TypeInformationDerivation.scala
@@ -5,12 +5,19 @@ import org.apache.flink.api.common.serialization.{SerializerConfig, SerializerCo
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.TypeSerializer
 import org.apache.flink.api.java.typeutils.runtime.NullableSerializer
-import org.apache.flinkx.api.serializer.{CaseClassSerializer, CoproductSerializer, ScalaCaseObjectSerializer, nullable}
+import org.apache.flinkx.api.serializer.{
+  CaseClassSerializer,
+  CoproductSerializer,
+  Scala3EnumSerializer,
+  Scala3EnumValueSerializer,
+  ScalaCaseObjectSerializer,
+  nullable
+}
 import org.apache.flinkx.api.typeinfo.{CaseClassTypeInfo, CoproductTypeInformation}
 import org.apache.flinkx.api.util.ClassUtil.isCaseClassImmutable
 
+import scala.IArray.given
 import scala.collection.mutable
-import scala.compiletime.summonInline
 import scala.reflect.ClassTag
 
 private[api] trait TypeInformationDerivation extends TaggedDerivation[TypeInformation]:
@@ -36,18 +43,18 @@ private[api] trait TypeInformationDerivation extends TaggedDerivation[TypeInform
       case None =>
         val clazz      = classTag.runtimeClass.asInstanceOf[Class[T & Product]]
         val serializer =
-          if typeTag.isModule then new ScalaCaseObjectSerializer[T & Product](clazz)
+          if typeTag.isEnum then
+            new Scala3EnumValueSerializer[T & Product](typeTag.companion.get.runtimeClass, ctx.typeInfo.short)
+          else if typeTag.isModule then new ScalaCaseObjectSerializer[T & Product](clazz)
           else
             new CaseClassSerializer[T & Product](
               clazz = clazz,
-              scalaFieldSerializers = IArray
-                .genericWrapArray(ctx.params.map { p =>
-                  val ser = p.typeclass.createSerializer(config)
-                  if (p.annotations.exists(_.isInstanceOf[nullable])) {
-                    NullableSerializer.wrapIfNullIsNotSupported(ser, true)
-                  } else ser
-                })
-                .toArray,
+              scalaFieldSerializers = ctx.params.map { p =>
+                val ser = p.typeclass.createSerializer(config)
+                if (p.annotations.exists(_.isInstanceOf[nullable])) {
+                  NullableSerializer.wrapIfNullIsNotSupported(ser, true)
+                } else ser
+              }.toArray,
               isCaseClassImmutable = isCaseClassImmutable(clazz, ctx.params.map(_.label))
             )
         val ti = new CaseClassTypeInfo[T & Product](
@@ -70,10 +77,17 @@ private[api] trait TypeInformationDerivation extends TaggedDerivation[TypeInform
         cached.asInstanceOf[TypeInformation[T]]
 
       case None =>
-        val serializer = new CoproductSerializer[T](
-          subtypeClasses = IArray.genericWrapArray(ctx.subtypes.map(_.typeclass.getTypeClass)).toArray,
-          subtypeSerializers = IArray.genericWrapArray(ctx.subtypes.map(_.typeclass.createSerializer(config))).toArray
-        )
+        val serializer =
+          if typeTag.isEnum then
+            new Scala3EnumSerializer[T & Product](
+              enumValueNames = ctx.subtypes.map(_.typeInfo.short).toArray,
+              enumValueSerializers = ctx.subtypes.map(_.typeclass.createSerializer(config)).toArray
+            ).asInstanceOf[TypeSerializer[T]]
+          else
+            new CoproductSerializer[T](
+              subtypeClasses = ctx.subtypes.map(_.typeclass.getTypeClass).toArray,
+              subtypeSerializers = ctx.subtypes.map(_.typeclass.createSerializer(config)).toArray
+            )
         val clazz = classTag.runtimeClass.asInstanceOf[Class[T]]
         val ti    = new CoproductTypeInformation[T](clazz, serializer)
         if useCache then cache.put(cacheKey, ti)

--- a/modules/flink-common-api/src/main/scala-3/org/apache/flinkx/api/TypeTag.scala
+++ b/modules/flink-common-api/src/main/scala-3/org/apache/flinkx/api/TypeTag.scala
@@ -1,12 +1,15 @@
 package org.apache.flinkx.api
 
 import scala.quoted.*
+import scala.reflect.ClassTag
 
 // A basic replacement for `TypeTag`, which is absent in Scala 3.
 trait TypeTag[A]:
   // Is the type a module, i.e. is it a case object?
   def isModule: Boolean
   def isCachable: Boolean
+  def isEnum: Boolean
+  def companion: Option[ClassTag[?]]
   def toString: String
 
 object TypeTag:

--- a/modules/flink-common-api/src/main/scala-3/org/apache/flinkx/api/TypeTag.scala
+++ b/modules/flink-common-api/src/main/scala-3/org/apache/flinkx/api/TypeTag.scala
@@ -5,10 +5,13 @@ import scala.reflect.ClassTag
 
 // A basic replacement for `TypeTag`, which is absent in Scala 3.
 trait TypeTag[A]:
-  // Is the type a module, i.e. is it a case object?
+  /** Is the type a module, i.e. is it a case object? */
   def isModule: Boolean
+  /** Determines if this type can be cached, i.e. must not be generic */
   def isCachable: Boolean
+  /** Is the type a Scala 3 enum? An enum value with parameters is not considered as enum to be handled as case class */
   def isEnum: Boolean
+  /** Returns the companion object ClassTag of this type if it exists */
   def companion: Option[ClassTag[?]]
   def toString: String
 

--- a/modules/flink-common-api/src/main/scala-3/org/apache/flinkx/api/TypeTagMacro.scala
+++ b/modules/flink-common-api/src/main/scala-3/org/apache/flinkx/api/TypeTagMacro.scala
@@ -1,6 +1,7 @@
 package org.apache.flinkx.api
 
 import scala.quoted.*
+import scala.reflect.ClassTag
 
 // Simple macro to derive a TypeTag for any type.
 object TypeTagMacro:
@@ -19,12 +20,22 @@ object TypeTagMacro:
     val flagsA         = symA.flags
     val isModuleExpr   = Expr(flagsA.is(Flags.Module))
     val isCachableExpr = Expr(check(A))
-
+    val enumSymbol     = Symbol.classSymbol("scala.reflect.Enum")
+    val isEnumExpr     = Expr(A.baseClasses.contains(enumSymbol) && symA.caseFields.isEmpty)
+    val companionExpr  = symA.companionClass.typeRef.asType match {
+      case '[companionType] =>
+        Expr.summon[ClassTag[companionType]] match {
+          case Some(ct) => '{ Some($ct) }
+          case None     => '{ None }
+        }
+    }
     val toStringExpr = Expr(A.show)
 
     '{
       new TypeTag[A]:
-        override lazy val isModule: Boolean   = ${ isModuleExpr }
-        override lazy val isCachable: Boolean = ${ isCachableExpr }
-        override lazy val toString: String    = ${ toStringExpr }
+        override lazy val isModule: Boolean              = ${ isModuleExpr }
+        override lazy val isCachable: Boolean            = ${ isCachableExpr }
+        override lazy val isEnum: Boolean                = ${ isEnumExpr }
+        override lazy val companion: Option[ClassTag[?]] = ${ companionExpr }
+        override lazy val toString: String               = ${ toStringExpr }
     }

--- a/modules/flink-common-api/src/main/scala-3/org/apache/flinkx/api/serializer/ConstructorCompat.scala
+++ b/modules/flink-common-api/src/main/scala-3/org/apache/flinkx/api/serializer/ConstructorCompat.scala
@@ -1,21 +1,23 @@
 package org.apache.flinkx.api.serializer
 
-import java.lang.reflect.Constructor
+import java.lang.reflect.Method
 import scala.util.control.NonFatal
 
 private[serializer] trait ConstructorCompat:
   // As of Scala version 3.1.2, there is no direct support for runtime reflection.
   // This is in contrast to Scala 2, which has its own APIs for reflecting on classes.
-  // Thus, fallback to Java reflection and look up the constructor matching the required signature.
+  // Thus, fallback to Java reflection and look up the apply method matching the required signature.
+  // Apply method is used because enum case classes cannot be instantiated by its constructor
   final def lookupConstructor[T](cls: Class[T]): Array[AnyRef] => T =
     // Types of parameters can fail to match when (un)boxing is used.
     // Say you have a class `final case class Foo(a: String, b: Int)`.
-    // The first parameter is an alias for `java.lang.String`, which the constructor uses.
-    // The second parameter is an alias for `java.lang.Integer`, but the constructor actually takes an unboxed `int`.
-    val constructor =
+    // The first parameter is an alias for `java.lang.String`, which the apply uses.
+    // The second parameter is an alias for `java.lang.Integer`, but the apply actually takes an unboxed `int`.
+    val applyMethod =
       try
-        cls.getConstructors
-          .foldLeft[Option[Constructor[?]]](None) {
+        cls.getMethods
+          .filter(_.getName == "apply")
+          .foldLeft[Option[Method]](None) {
             case (Some(longest), c) if longest.getParameterCount < c.getParameterCount => Some(c)
             case (_, c)                                                                => Some(c)
           }
@@ -40,6 +42,6 @@ private[serializer] trait ConstructorCompat:
 
     (args: Array[AnyRef]) => {
       // Append default values for missing arguments
-      val allArgs = args ++ defaultArgs.takeRight(constructor.getParameterCount - args.length)
-      constructor.newInstance(allArgs*).asInstanceOf[T]
+      val allArgs = args ++ defaultArgs.takeRight(applyMethod.getParameterCount - args.length)
+      applyMethod.invoke(null, allArgs*).asInstanceOf[T]
     }

--- a/modules/flink-common-api/src/main/scala-3/org/apache/flinkx/api/serializer/Scala3EnumSerializer.scala
+++ b/modules/flink-common-api/src/main/scala-3/org/apache/flinkx/api/serializer/Scala3EnumSerializer.scala
@@ -1,13 +1,14 @@
 package org.apache.flinkx.api.serializer
 
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerUtil.setNestedSerializersSnapshots
+import org.apache.flink.api.common.typeutils.base.array.StringArraySerializer
 import org.apache.flink.api.common.typeutils.{CompositeTypeSerializerSnapshot, TypeSerializer, TypeSerializerSnapshot}
 import org.apache.flink.core.memory.{DataInputView, DataOutputView}
 import org.apache.flinkx.api.{NullMarkerByte, VariableLengthDataType}
 
 /** Serializer for Scala 3 enum. Handle nullable value. */
 class Scala3EnumSerializer[T <: Product](
-    enumValueNames: Array[String],
+    val enumValueNames: Array[String],
     val enumValueSerializers: Array[TypeSerializer[_]]
 ) extends MutableSerializer[T] {
 
@@ -69,9 +70,11 @@ class Scala3EnumSerializer[T <: Product](
 
   override def copy(source: DataInputView, target: DataOutputView): Unit = {
     val index   = source.readByte()
-    val subtype = enumValueSerializers(index.toInt)
     target.writeByte(index)
-    subtype.asInstanceOf[TypeSerializer[T]].copy(source, target)
+    if (index != NullMarkerByte) {
+      val subtype = enumValueSerializers(index.toInt)
+      subtype.asInstanceOf[TypeSerializer[T]].copy(source, target)
+    }
   }
 
   override def snapshotConfiguration(): TypeSerializerSnapshot[T] = new Scala3EnumSerializerSnapshot(Some(this))
@@ -86,9 +89,12 @@ class Scala3EnumSerializerSnapshot[T <: Product](
   // Empty constructor is required to instantiate this class during deserialization.
   def this() = this(None)
 
+  private var enumValueNames: Array[String] = Array.empty
+
   serializer.foreach { s =>
     // Scala limitation: can't call parent constructor used for writing the snapshot, reproduce its behavior instead
     setNestedSerializersSnapshots(this, getNestedSerializers(s).map(_.snapshotConfiguration()): _*)
+    enumValueNames = s.enumValueNames
   }
 
   override def getCurrentOuterSnapshotVersion: Int = Scala3EnumSerializerSnapshot.CurrentVersion
@@ -99,8 +105,14 @@ class Scala3EnumSerializerSnapshot[T <: Product](
   override protected def createOuterSerializerWithNestedSerializers(
       nestedSerializers: Array[TypeSerializer[_]]
   ): Scala3EnumSerializer[T] =
-    // Serializer created by snapshot is only used to deserialize: first parameter is useless
-    new Scala3EnumSerializer(Array.empty, nestedSerializers)
+    new Scala3EnumSerializer(enumValueNames, nestedSerializers)
+
+  override def writeOuterSnapshot(out: DataOutputView): Unit =
+    StringArraySerializer.INSTANCE.serialize(enumValueNames, out)
+
+  override def readOuterSnapshot(readOuterSnapshotVersion: Int, in: DataInputView, cl: ClassLoader): Unit = {
+    enumValueNames = StringArraySerializer.INSTANCE.deserialize(in)
+  }
 
 }
 

--- a/modules/flink-common-api/src/main/scala-3/org/apache/flinkx/api/serializer/Scala3EnumSerializer.scala
+++ b/modules/flink-common-api/src/main/scala-3/org/apache/flinkx/api/serializer/Scala3EnumSerializer.scala
@@ -1,0 +1,109 @@
+package org.apache.flinkx.api.serializer
+
+import org.apache.flink.api.common.typeutils.CompositeTypeSerializerUtil.setNestedSerializersSnapshots
+import org.apache.flink.api.common.typeutils.{CompositeTypeSerializerSnapshot, TypeSerializer, TypeSerializerSnapshot}
+import org.apache.flink.core.memory.{DataInputView, DataOutputView}
+import org.apache.flinkx.api.{NullMarkerByte, VariableLengthDataType}
+
+/** Serializer for Scala 3 enum. Handle nullable value. */
+class Scala3EnumSerializer[T <: Product](
+    enumValueNames: Array[String],
+    val enumValueSerializers: Array[TypeSerializer[_]]
+) extends MutableSerializer[T] {
+
+  override val isImmutableType: Boolean = enumValueSerializers.forall(_.isImmutableType)
+  val isImmutableSerializer: Boolean    = enumValueSerializers.forall(s => s.duplicate().eq(s))
+
+  override def copy(from: T): T = {
+    if (from == null || isImmutableType) {
+      from
+    } else {
+      val i = enumValueNames.indexOf(from.productPrefix) // productPrefix returns enum value name even for case class
+      enumValueSerializers(i).asInstanceOf[TypeSerializer[T]].copy(from)
+    }
+  }
+
+  override def duplicate(): Scala3EnumSerializer[T] = {
+    if (isImmutableSerializer) {
+      this
+    } else {
+      new Scala3EnumSerializer[T](enumValueNames, enumValueSerializers.map(_.duplicate()))
+    }
+  }
+
+  override def createInstance(): T =
+    enumValueSerializers.head.createInstance().asInstanceOf[T]
+
+  override val getLength: Int = {
+    val length = enumValueSerializers(0).getLength
+    if (enumValueSerializers.forall(_.getLength == length)) {
+      length
+    } else {
+      VariableLengthDataType
+    }
+  }
+
+  override def serialize(record: T, target: DataOutputView): Unit = {
+    if (record == null) {
+      target.writeByte(NullMarkerByte)
+    } else {
+      val enumValueIndex = enumValueNames.indexOf(record.productPrefix) // returns enum value name even for case class
+      if (enumValueIndex >= 0) {
+        target.writeByte(enumValueIndex)
+        enumValueSerializers(enumValueIndex).asInstanceOf[TypeSerializer[T]].serialize(record, target)
+      } else {
+        throw new IllegalStateException("enum value not found in enum schema")
+      }
+    }
+  }
+
+  override def deserialize(source: DataInputView): T = {
+    val index = source.readByte()
+    if (index == NullMarkerByte) {
+      null.asInstanceOf[T]
+    } else {
+      val subtype = enumValueSerializers(index.toInt)
+      subtype.asInstanceOf[TypeSerializer[T]].deserialize(source)
+    }
+  }
+
+  override def copy(source: DataInputView, target: DataOutputView): Unit = {
+    val index   = source.readByte()
+    val subtype = enumValueSerializers(index.toInt)
+    target.writeByte(index)
+    subtype.asInstanceOf[TypeSerializer[T]].copy(source, target)
+  }
+
+  override def snapshotConfiguration(): TypeSerializerSnapshot[T] = new Scala3EnumSerializerSnapshot(Some(this))
+
+}
+
+/** Serializer snapshot for Scala 3 enum. */
+class Scala3EnumSerializerSnapshot[T <: Product](
+    serializer: Option[Scala3EnumSerializer[T]]
+) extends CompositeTypeSerializerSnapshot[T, Scala3EnumSerializer[T]] {
+
+  // Empty constructor is required to instantiate this class during deserialization.
+  def this() = this(None)
+
+  serializer.foreach { s =>
+    // Scala limitation: can't call parent constructor used for writing the snapshot, reproduce its behavior instead
+    setNestedSerializersSnapshots(this, getNestedSerializers(s).map(_.snapshotConfiguration()): _*)
+  }
+
+  override def getCurrentOuterSnapshotVersion: Int = Scala3EnumSerializerSnapshot.CurrentVersion
+
+  override protected def getNestedSerializers(outerSerializer: Scala3EnumSerializer[T]): Array[TypeSerializer[_]] =
+    outerSerializer.enumValueSerializers
+
+  override protected def createOuterSerializerWithNestedSerializers(
+      nestedSerializers: Array[TypeSerializer[_]]
+  ): Scala3EnumSerializer[T] =
+    // Serializer created by snapshot is only used to deserialize: first parameter is useless
+    new Scala3EnumSerializer(Array.empty, nestedSerializers)
+
+}
+
+object Scala3EnumSerializerSnapshot {
+  private val CurrentVersion = 1
+}

--- a/modules/flink-common-api/src/main/scala-3/org/apache/flinkx/api/serializer/Scala3EnumValueSerializer.scala
+++ b/modules/flink-common-api/src/main/scala-3/org/apache/flinkx/api/serializer/Scala3EnumValueSerializer.scala
@@ -1,0 +1,54 @@
+package org.apache.flinkx.api.serializer
+
+import org.apache.flink.api.common.typeutils.{TypeSerializer, TypeSerializerSchemaCompatibility, TypeSerializerSnapshot}
+import org.apache.flink.core.memory.{DataInputView, DataOutputView}
+import org.apache.flink.util.InstantiationUtil
+
+/** Serializer for Scala 3 enum value. */
+class Scala3EnumValueSerializer[T](companionClass: Class[_], enumValueName: String) extends ImmutableSerializer[T] {
+
+  private lazy val enumValue: T = companionClass.getField(enumValueName).get(null).asInstanceOf[T]
+
+  override def copy(source: DataInputView, target: DataOutputView): Unit = {}
+  override def createInstance(): T                                       = enumValue
+  override def getLength: Int                                            = 0
+  override def serialize(record: T, target: DataOutputView): Unit        = {}
+  override def deserialize(source: DataInputView): T                     = enumValue
+
+  override def snapshotConfiguration(): TypeSerializerSnapshot[T] =
+    new Scala3EnumValueSerializerSnapshot(companionClass, enumValueName)
+}
+
+/** Serializer snapshot for Scala 3 enum value. */
+class Scala3EnumValueSerializerSnapshot[T](
+    var companionClass: Class[_],
+    var enumValueName: String
+) extends TypeSerializerSnapshot[T] {
+
+  // Empty constructor is required to instantiate this class during deserialization.
+  def this() = this(null, null)
+
+  override def readSnapshot(readVersion: Int, in: DataInputView, userCodeClassLoader: ClassLoader): Unit = {
+    companionClass = InstantiationUtil.resolveClassByName(in, userCodeClassLoader)
+    enumValueName = in.readUTF()
+  }
+
+  override def writeSnapshot(out: DataOutputView): Unit = {
+    out.writeUTF(companionClass.getName)
+    out.writeUTF(enumValueName)
+  }
+
+  override def getCurrentVersion: Int = Scala3EnumValueSerializerSnapshot.CurrentVersion
+
+  override def resolveSchemaCompatibility(
+      oldSerializer: TypeSerializerSnapshot[T]
+  ): TypeSerializerSchemaCompatibility[T] =
+    TypeSerializerSchemaCompatibility.compatibleAsIs()
+
+  override def restoreSerializer(): TypeSerializer[T] = new Scala3EnumValueSerializer[T](companionClass, enumValueName)
+
+}
+
+object Scala3EnumValueSerializerSnapshot {
+  private val CurrentVersion = 1
+}

--- a/modules/flink-common-api/src/main/scala/org/apache/flinkx/api/package.scala
+++ b/modules/flink-common-api/src/main/scala/org/apache/flinkx/api/package.scala
@@ -28,5 +28,6 @@ package object api {
     * [[NullableSerializer]].
     */
   private[api] val NullMarker: Int = Int.MinValue
+  private[api] val NullMarkerByte: Byte = Byte.MinValue
 
 }

--- a/modules/flink-common-api/src/main/scala/org/apache/flinkx/api/serializer/CoproductSerializer.scala
+++ b/modules/flink-common-api/src/main/scala/org/apache/flinkx/api/serializer/CoproductSerializer.scala
@@ -2,7 +2,12 @@ package org.apache.flinkx.api.serializer
 
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerUtil.setNestedSerializersSnapshots
 import org.apache.flink.api.common.typeutils.base.array.StringArraySerializer
-import org.apache.flink.api.common.typeutils.{CompositeTypeSerializerSnapshot, TypeSerializer, TypeSerializerSchemaCompatibility, TypeSerializerSnapshot}
+import org.apache.flink.api.common.typeutils.{
+  CompositeTypeSerializerSnapshot,
+  TypeSerializer,
+  TypeSerializerSchemaCompatibility,
+  TypeSerializerSnapshot
+}
 import org.apache.flink.core.memory.{DataInputView, DataOutputView}
 import org.apache.flink.util.InstantiationUtil
 import org.apache.flinkx.api.VariableLengthDataType
@@ -91,7 +96,7 @@ object CoproductSerializer {
     // Empty constructor is required to instantiate this class during deserialization.
     def this() = this(None)
 
-    private var subtypeClasses: Array[Class[_]] = Array.empty
+    private var subtypeClasses: Array[Class[_]]              = Array.empty
     private var subtypeSerializers: Array[TypeSerializer[_]] = Array.empty
 
     // An adapter is mandatory to keep the compatibility during the transition to a CompositeTypeSerializerSnapshot

--- a/modules/flink-common-api/src/main/scala/org/apache/flinkx/api/serializer/CoproductSerializer.scala
+++ b/modules/flink-common-api/src/main/scala/org/apache/flinkx/api/serializer/CoproductSerializer.scala
@@ -1,17 +1,15 @@
 package org.apache.flinkx.api.serializer
 
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerUtil.setNestedSerializersSnapshots
-import org.apache.flink.api.common.typeutils.{
-  CompositeTypeSerializerSnapshot,
-  TypeSerializer,
-  TypeSerializerSchemaCompatibility,
-  TypeSerializerSnapshot
-}
+import org.apache.flink.api.common.typeutils.base.array.StringArraySerializer
+import org.apache.flink.api.common.typeutils.{CompositeTypeSerializerSnapshot, TypeSerializer, TypeSerializerSchemaCompatibility, TypeSerializerSnapshot}
 import org.apache.flink.core.memory.{DataInputView, DataOutputView}
+import org.apache.flink.util.InstantiationUtil
 import org.apache.flinkx.api.VariableLengthDataType
 import org.apache.flinkx.api.serializer.CoproductSerializer.CoproductSerializerSnapshot
+import org.apache.flinkx.api.util.ClassUtil
 
-class CoproductSerializer[T](subtypeClasses: Array[Class[_]], val subtypeSerializers: Array[TypeSerializer[_]])
+class CoproductSerializer[T](val subtypeClasses: Array[Class[_]], val subtypeSerializers: Array[TypeSerializer[_]])
     extends MutableSerializer[T] {
 
   override val isImmutableType: Boolean = subtypeSerializers.forall(_.isImmutableType)
@@ -93,6 +91,7 @@ object CoproductSerializer {
     // Empty constructor is required to instantiate this class during deserialization.
     def this() = this(None)
 
+    private var subtypeClasses: Array[Class[_]] = Array.empty
     private var subtypeSerializers: Array[TypeSerializer[_]] = Array.empty
 
     // An adapter is mandatory to keep the compatibility during the transition to a CompositeTypeSerializerSnapshot
@@ -100,23 +99,30 @@ object CoproductSerializer {
     private val adapter: CompositeTypeSerializerSnapshot[T, CoproductSerializer[T]] =
       new CompositeTypeSerializerSnapshot[T, CoproductSerializer[T]] {
 
-        private var nestedSerializers: Array[TypeSerializer[_]] = Array.empty
-
         serializer.foreach { s =>
           // Scala limitation: can't call parent constructor used for writing the snapshot, reproduce its behavior instead
-          this.nestedSerializers = s.subtypeSerializers
+          subtypeClasses = s.subtypeClasses
+          subtypeSerializers = s.subtypeSerializers
           setNestedSerializersSnapshots(this, getNestedSerializers(s).map(_.snapshotConfiguration()): _*)
         }
 
         override def getCurrentOuterSnapshotVersion: Int = CurrentVersion
 
         override def getNestedSerializers(outerSerializer: CoproductSerializer[T]): Array[TypeSerializer[_]] =
-          this.nestedSerializers
+          subtypeSerializers
 
         override def createOuterSerializerWithNestedSerializers(
             nestedSerializers: Array[TypeSerializer[_]]
         ): CoproductSerializer[T] =
-          new CoproductSerializer[T](Array.empty, nestedSerializers)
+          new CoproductSerializer[T](subtypeClasses, nestedSerializers)
+
+        override def writeOuterSnapshot(out: DataOutputView): Unit =
+          StringArraySerializer.INSTANCE.serialize(subtypeClasses.map(_.getName), out)
+
+        override def readOuterSnapshot(readOuterSnapshotVersion: Int, in: DataInputView, cl: ClassLoader): Unit = {
+          subtypeClasses = StringArraySerializer.INSTANCE.deserialize(in).map(ClassUtil.resolveClassByName(_, cl))
+        }
+
       }
 
     override def getCurrentVersion: Int = adapter.getCurrentVersion
@@ -127,8 +133,9 @@ object CoproductSerializer {
       if (readVersion == 2) {
         val len = in.readInt()
 
-        // Unused
-        (0 until len).foreach(_ => in.readUTF())
+        subtypeClasses = (0 until len)
+          .map(_ => InstantiationUtil.resolveClassByName(in, userCodeClassLoader))
+          .toArray
 
         subtypeSerializers = (0 until len)
           .map(_ => TypeSerializerSnapshot.readVersionedSnapshot(in, userCodeClassLoader).restoreSerializer())
@@ -145,7 +152,7 @@ object CoproductSerializer {
       if (subtypeSerializers.isEmpty) {
         adapter.restoreSerializer() // Restore from adapter
       } else {
-        new CoproductSerializer[T](Array.empty, subtypeSerializers) // Restore from readSnapshot
+        new CoproductSerializer[T](subtypeClasses, subtypeSerializers) // Restore from readSnapshot
       }
 
   }

--- a/modules/flink-common-api/src/main/scala/org/apache/flinkx/api/util/ClassUtil.scala
+++ b/modules/flink-common-api/src/main/scala/org/apache/flinkx/api/util/ClassUtil.scala
@@ -1,5 +1,7 @@
 package org.apache.flinkx.api.util
 
+import org.apache.flink.util.FlinkRuntimeException
+
 import java.lang.reflect.{Field, Modifier}
 
 object ClassUtil {
@@ -22,6 +24,14 @@ object ClassUtil {
         // return true if the field isn't found in the class: case classes can only override val from parent classes
         .forall(field => Modifier.isFinal(field.getModifiers))
     )
+  }
+
+  def resolveClassByName[T](className: String, cl: ClassLoader): Class[T] = {
+    try {
+      Class.forName(className, false, cl).asInstanceOf[Class[T]]
+    } catch {
+      case e: ClassNotFoundException => throw new FlinkRuntimeException(e)
+    }
   }
 
 }

--- a/modules/flink-common-api/src/test/scala-3/org/apache/flinkx/api/Scala3EnumTest.scala
+++ b/modules/flink-common-api/src/test/scala-3/org/apache/flinkx/api/Scala3EnumTest.scala
@@ -37,19 +37,19 @@ class Scala3EnumTest extends AnyFlatSpec with Matchers with TestUtils {
   }
 
   it should "roundtrip an enum with a case with parameters" in {
-    testTypeInfoAndSerializer[Example](Foo("a", 2), false)
+    testTypeInfoAndSerializer[Example](Foo("a", 2))
   }
 
   it should "roundtrip an enum value with parameters" in {
-    testTypeInfoAndSerializer[Foo](Foo("a", 2), false)
+    testTypeInfoAndSerializer[Foo](Foo("a", 2))
   }
 
   it should "roundtrip a case class declaring an enum" in {
-    testTypeInfoAndSerializer(FailureEvent("a", PARSING), false)
+    testTypeInfoAndSerializer(FailureEvent("a", PARSING))
   }
 
   it should "roundtrip a case class declaring an enum value" in {
-    testTypeInfoAndSerializer(FooEvent("a", Foo("a", 2)), false)
+    testTypeInfoAndSerializer(FooEvent("a", Foo("a", 2)))
   }
 
 }

--- a/modules/flink-common-api/src/test/scala-3/org/apache/flinkx/api/Scala3EnumTest.scala
+++ b/modules/flink-common-api/src/test/scala-3/org/apache/flinkx/api/Scala3EnumTest.scala
@@ -3,24 +3,76 @@ package org.apache.flinkx.api
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flinkx.api.auto.*
 
-import org.apache.flinkx.api.semiauto.*
+class Scala3EnumTest extends AnyFlatSpec with Matchers with TestUtils {
 
-class Scala3EnumTest extends AnyFlatSpec with Matchers {
+  import Scala3EnumTest.Failure
+  import Scala3EnumTest.Failure.*
+  import Scala3EnumTest.FailureCategory
+  import Scala3EnumTest.FailureCategory.*
   import Scala3EnumTest.Example
+  import Scala3EnumTest.Example.*
+  import Scala3EnumTest.FailureEvent
+  import Scala3EnumTest.FooEvent
 
   it should "derive type information for a Scala 3 enum" in {
     summon[TypeInformation[Example]] shouldNot be(null)
   }
+
+  it should "derive type information for a Scala 3 enum value" in {
+    summon[TypeInformation[Foo]] shouldNot be(null)
+  }
+
+  it should "roundtrip a enum" in {
+    testTypeInfoAndSerializer(PARSE_ERROR, false)
+  }
+
+  it should "roundtrip an enum with parameter" in {
+    testTypeInfoAndSerializer(PARSING, false)
+  }
+
+  it should "roundtrip an enum with a simple case" in {
+    testTypeInfoAndSerializer(Bar, false)
+  }
+
+  it should "roundtrip an enum with a case with parameters" in {
+    testTypeInfoAndSerializer[Example](Foo("a", 2), false)
+  }
+
+  it should "roundtrip an enum value with parameters" in {
+    testTypeInfoAndSerializer[Foo](Foo("a", 2), false)
+  }
+
+  it should "roundtrip a case class declaring an enum" in {
+    testTypeInfoAndSerializer(FailureEvent("a", PARSING), false)
+  }
+
+  it should "roundtrip a case class declaring an enum value" in {
+    testTypeInfoAndSerializer(FooEvent("a", Foo("a", 2)), false)
+  }
+
 }
 
 object Scala3EnumTest {
+
+  enum Failure {
+    case MISSING_KEY, PARSE_ERROR, UNKNOWN
+  }
+
+  enum FailureCategory(a: Int) {
+    case MISSING extends FailureCategory(1)
+    case PARSING extends FailureCategory(2)
+    case OTHER extends FailureCategory(3)
+  }
+
   enum Example {
     case Foo(a: String, b: Int)
     case Bar
   }
 
-  object Example {
-    implicit val exampleTi: TypeInformation[Example] = deriveTypeInformation
-  }
+  case class FailureEvent(step: String, category: FailureCategory)
+
+  case class FooEvent(step: String, foo: Example.Foo)
+
 }

--- a/modules/flink-common-api/src/test/scala/org/apache/flinkx/api/TestUtils.scala
+++ b/modules/flink-common-api/src/test/scala/org/apache/flinkx/api/TestUtils.scala
@@ -137,6 +137,7 @@ trait TestUtils extends Matchers with Inspectors {
     if (nullable) {
       withClue("The serializer must handle null but didn't:") {
         NullableSerializer.checkIfNullSupported(ser) shouldBe true
+        checkDataViewCopy(ser, null.asInstanceOf[T], assertion)
       }
     }
   }


### PR DESCRIPTION
Hi @novakov-alexey, @kirksw
Here is my proposal to handle correctly Scala 3 enums and enum values and fix https://github.com/flink-extended/flink-scala-api/issues/359.

Enums (eg `FailureCategory`) are Sums like sealed traits and must be handled in `TypeInformationDerivation.split` but are significatively different to sealed trait to require a special handling:
- in sealed traits, subtypes can be identified by their class
- with enums, their subtypes (enum values) cannot be identified by their class because they all have the same class but by their enum value name.

Difference big enough to have to create a new `Scala3EnumSerializer` similar to `CoproductSerializer`.

Enum values (eg `case MISSING_KEY`) are Products like case objects and must be handled in `TypeInformationDerivation.join` but are also significatively different to case objects for the same reason, but also because enum values cannot be found the same way:
- case objects have a `MODULE$` static field which hold their singleton.
- singleton of enum value are in static fields in the companion object of their enum, named with their enum value name.

In a same way I had to create a specific `Scala3EnumValueSerializer` similar to `ScalaCaseObjectSerializer`.

In order to identify if the derived type is an enum, I added a `TypeTag.isEnum` method in our TypeTag macro which check if it has a `scala.reflect.Enum` trait, AND don't have parameters (more on that later).

I also managed to add a `TypeTag.companion` method returning its companion object ClassTag if it exists (it should be always the case for enums) to pass it to the `Scala3EnumValueSerializer`.

Macro syntax is such a pain! Feel free to improve what I've done. I don't know if it can be simplified, but it works as is.

Last thing is the possibility to declare enum values like case classes:
```
  enum Example {
    case Foo(a: String, b: Int)
    case Bar
  }
```
Here `Foo` is an enum value but also a regular case class except it cannot be instantiated by its constructor (expected for an enum value).

I think the best way to handle this case is to consider it as a case class and handle it with a `CaseClassSerializer`. That's why I added in `TypeTag.isEnum` the check "have NO parameters" to fallback to case class.

Because of the new constraint on the constructor, case classes has to be created using their `apply` method (changes in `ConstructorCompat`), but I don't see any drawback to do so.

@novakov-alexey, I'm taking holidays for 1 week, so if you have some adjustments to do, feel free to do it!