### PR TITLE
Trigger "All tests" CI pushing on all branches, not only master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   # Job 1: Full test coverage (all projects)
   java-17-full:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ name: All Tests
 
 on:
   push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
Hi @novakov-alexey,

Small CI tweak: the "All Tests" workflow currently only runs on `push` events targeting `master`, which means contributors get no CI feedback on their feature branches until they open a PR.

This PR removes the `branches: [ master ]` filter on the `push` trigger so the workflow also runs on pushes to feature branches and adds auto-cancel of redundant runs, pushes that arrive while a PR run is in flight will cancel each other.

Thanks