### PR TITLE
Change cache to a TrieMap to handle concurrent derivation

### DIFF
--- a/modules/flink-common-api/src/main/scala-2/org/apache/flinkx/api/TypeInformationDerivation.scala
+++ b/modules/flink-common-api/src/main/scala-2/org/apache/flinkx/api/TypeInformationDerivation.scala
@@ -8,7 +8,7 @@ import org.apache.flinkx.api.serializer.{CaseClassSerializer, CoproductSerialize
 import org.apache.flinkx.api.typeinfo.{CaseClassTypeInfo, CoproductTypeInformation}
 import org.apache.flinkx.api.util.ClassUtil.isCaseClassImmutable
 
-import scala.collection.mutable
+import scala.collection.concurrent.TrieMap
 import scala.reflect.runtime.universe.{TypeTag, typeOf}
 import scala.reflect.{ClassTag, classTag}
 
@@ -18,7 +18,7 @@ private[api] trait TypeInformationDerivation {
 
   private val config: SerializerConfig = new SerializerConfigImpl()
 
-  protected val cache: mutable.Map[String, TypeInformation[_]] = mutable.Map.empty
+  protected[api] val cache: TrieMap[String, TypeInformation[_]] = TrieMap.empty
 
   def join[T <: Product: ClassTag: TypeTag](
       ctx: CaseClass[TypeInformation, T]
@@ -48,8 +48,7 @@ private[api] trait TypeInformationDerivation {
           fieldNames = ctx.parameters.map(_.label),
           ser = serializer
         )
-        cache.put(cacheKey, ti)
-        ti
+        cache.putIfAbsent(cacheKey, ti).getOrElse(ti).asInstanceOf[TypeInformation[T]]
     }
   }
 
@@ -64,8 +63,7 @@ private[api] trait TypeInformationDerivation {
         )
         val clazz = classTag[T].runtimeClass.asInstanceOf[Class[T]]
         val ti    = new CoproductTypeInformation[T](clazz, serializer)
-        cache.put(cacheKey, ti)
-        ti
+        cache.putIfAbsent(cacheKey, ti).getOrElse(ti).asInstanceOf[TypeInformation[T]]
     }
   }
 

--- a/modules/flink-common-api/src/main/scala-3/org/apache/flinkx/api/TypeInformationDerivation.scala
+++ b/modules/flink-common-api/src/main/scala-3/org/apache/flinkx/api/TypeInformationDerivation.scala
@@ -17,7 +17,7 @@ import org.apache.flinkx.api.typeinfo.{CaseClassTypeInfo, CoproductTypeInformati
 import org.apache.flinkx.api.util.ClassUtil.isCaseClassImmutable
 
 import scala.IArray.genericWrapArray
-import scala.collection.mutable
+import scala.collection.concurrent.TrieMap
 import scala.reflect.ClassTag
 
 private[api] trait TypeInformationDerivation extends TaggedDerivation[TypeInformation]:
@@ -26,7 +26,7 @@ private[api] trait TypeInformationDerivation extends TaggedDerivation[TypeInform
 
   private val config: SerializerConfig = new SerializerConfigImpl()
 
-  protected val cache: mutable.Map[String, TypeInformation[?]] = mutable.Map.empty
+  protected[api] val cache: TrieMap[String, TypeInformation[?]] = TrieMap.empty
 
   // We cannot add a constraint of `T <: Product`, even though `join` is always called on products.
   // Need to mix in via `& Product`.
@@ -63,8 +63,8 @@ private[api] trait TypeInformationDerivation extends TaggedDerivation[TypeInform
           fieldNames = ctx.params.map(_.label),
           ser = serializer
         ).asInstanceOf[TypeInformation[T]]
-        if useCache then cache.put(cacheKey, ti)
-        ti
+        if useCache then cache.putIfAbsent(cacheKey, ti).getOrElse(ti).asInstanceOf[TypeInformation[T]]
+        else ti
 
   override def split[T](ctx: SealedTrait[Typeclass, T])(using
       classTag: ClassTag[T],
@@ -90,5 +90,5 @@ private[api] trait TypeInformationDerivation extends TaggedDerivation[TypeInform
             )
         val clazz = classTag.runtimeClass.asInstanceOf[Class[T]]
         val ti    = new CoproductTypeInformation[T](clazz, serializer)
-        if useCache then cache.put(cacheKey, ti)
-        ti
+        if useCache then cache.putIfAbsent(cacheKey, ti).getOrElse(ti).asInstanceOf[TypeInformation[T]]
+        else ti

--- a/modules/flink-common-api/src/test/scala-2/org/apache/flinkx/api/RecursiveDerivationTest.scala
+++ b/modules/flink-common-api/src/test/scala-2/org/apache/flinkx/api/RecursiveDerivationTest.scala
@@ -1,0 +1,21 @@
+package org.apache.flinkx.api
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flinkx.api.RecursiveDerivationTest.RecursiveNode
+import org.apache.flinkx.api.auto._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class RecursiveDerivationTest extends AnyFunSuite with Matchers {
+
+  test("Recursive derivation is not supported and fails with a StackOverflowError") {
+    assertThrows[StackOverflowError](implicitly[TypeInformation[RecursiveNode]])
+  }
+
+}
+
+object RecursiveDerivationTest {
+
+  case class RecursiveNode(left: Option[RecursiveNode], right: Option[RecursiveNode])
+
+}

--- a/modules/flink-common-api/src/test/scala/org/apache/flinkx/api/ConcurrentDerivationTest.scala
+++ b/modules/flink-common-api/src/test/scala/org/apache/flinkx/api/ConcurrentDerivationTest.scala
@@ -1,0 +1,76 @@
+package org.apache.flinkx.api
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flinkx.api.ConcurrentDerivationTest._
+import org.apache.flinkx.api.auto._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util.concurrent.{Callable, CountDownLatch, Executors, TimeUnit}
+
+class ConcurrentDerivationTest extends AnyFlatSpec with Matchers {
+
+  it should "produce a singleton TypeInformation per type even when several threads derive types sharing subtypes" in {
+    val threads    = 16
+    val iterations = 50
+
+    val tasks: Seq[() => TypeInformation[_]] = Seq(
+      () => implicitly[TypeInformation[Holder1]],
+      () => implicitly[TypeInformation[Holder2]],
+      () => implicitly[TypeInformation[Holder3]],
+      () => implicitly[TypeInformation[Holder4]],
+      () => implicitly[TypeInformation[Holder5]],
+      () => implicitly[TypeInformation[Holder6]],
+      () => implicitly[TypeInformation[Holder7]],
+      () => implicitly[TypeInformation[Holder8]]
+    )
+
+    (1 to iterations).foreach { _ =>
+      // Clear the cache at each iteration to force re-derivation
+      auto.cache.clear()
+
+      val pool  = Executors.newFixedThreadPool(threads)
+      val start = new CountDownLatch(1)
+      try {
+        val futures = (0 until threads).map { i =>
+          pool.submit(new Callable[(Int, TypeInformation[_])] {
+            override def call(): (Int, TypeInformation[_]) = {
+              start.await()
+              val taskIndex = i % tasks.size
+              (taskIndex, tasks(taskIndex)())
+            }
+          })
+        }
+        start.countDown()
+        val results = futures.map(_.get(30, TimeUnit.SECONDS))
+        results should have size threads.toLong
+
+        // Cache identity must be preserved across threads
+        results.groupBy(_._1).values.foreach { sameTypeResults =>
+          val tis = sameTypeResults.map(_._2)
+          all(tis) should be theSameInstanceAs tis.head
+        }
+      } finally {
+        pool.shutdownNow()
+      }
+    }
+  }
+
+}
+
+object ConcurrentDerivationTest {
+
+  case class SharedA(a: Int, b: String)
+  case class SharedB(c: Long, d: Double)
+
+  // Distinct top-level types sharing the same subtypes, so concurrent derivations race on the shared subtypes.
+  case class Holder1(s1: SharedA, s2: SharedB, t: (Int, String))
+  case class Holder2(s1: SharedA, s2: SharedB, t: (Int, String))
+  case class Holder3(s1: SharedA, s2: SharedB, t: (Int, String))
+  case class Holder4(s1: SharedA, s2: SharedB, t: (Int, String))
+  case class Holder5(s1: SharedA, s2: SharedB, t: (Int, String))
+  case class Holder6(s1: SharedA, s2: SharedB, t: (Int, String))
+  case class Holder7(s1: SharedA, s2: SharedB, t: (Int, String))
+  case class Holder8(s1: SharedA, s2: SharedB, t: (Int, String))
+
+}

--- a/modules/flink-common-api/src/test/scala/org/apache/flinkx/api/SerializerTest.scala
+++ b/modules/flink-common-api/src/test/scala/org/apache/flinkx/api/SerializerTest.scala
@@ -76,11 +76,6 @@ class SerializerTest extends AnyFlatSpec with Matchers with Inspectors with Test
     testSerializer(Nil, nullable = false)
   }
 
-  it should "derive recursively" in {
-    // recursive is broken
-    // val ti = implicitly[TypeInformation[Node]]
-  }
-
   it should "derive list" in {
     testTypeInfoAndSerializer(List(Simple(1, "a")), nullable = false)
   }
@@ -505,8 +500,6 @@ object SerializerTest {
   }
   case class P1(a: String) extends Param[String]
   case class P2(a: Int)    extends Param[Int]
-
-  case class Node(left: Option[Node], right: Option[Node])
 
   case class SimpleOption(a: Option[String])
 


### PR DESCRIPTION
Hi @novakov-alexey,

Here is a small follow-up to #387 to give the type-information derivation cache a minimal handling of concurrent derivation.

The new `ConcurrentDerivationTest` reliably reproduces the original `Unsupported: recursivity detected in '...'` we hit on production under high parallelism.
After the revert of #280, that false-positive is gone, but the test now exposes another gap on `master`: the cache doesn't guarantee the identity of its cached values when threads race on the same type. Two threads can both miss the cache, both compute their own `TypeInformation`, and both `put` — leaving one embedded inside a parent type while another sits in the cache.
Nothing critical but it's worth to improve this to ensure that all threads deriving the same top-level type return the exact same `TypeInformation` instance.

This PR addresses both with two minimal changes:
 - `mutable.Map` → `scala.collection.concurrent.TrieMap` for thread-safe individual ops.
 - `cache.put(...)` → `cache.putIfAbsent(...).getOrElse(ti)` so the first thread to publish wins and every other thread returns the winner.

`RecursiveDerivationTest` documents that recursive types now fail with `StackOverflowError`, which is the currently expected behavior since #387 reverted the recursivity detection.

Thanks