### PR TITLE
CoproductSerializer: add null handling and fix schema compatibility resolution

### DIFF
--- a/modules/flink-common-api/src/main/scala/org/apache/flinkx/api/serializer/CoproductSerializer.scala
+++ b/modules/flink-common-api/src/main/scala/org/apache/flinkx/api/serializer/CoproductSerializer.scala
@@ -97,8 +97,7 @@ object CoproductSerializer {
     // Empty constructor is required to instantiate this class during deserialization.
     def this() = this(None)
 
-    private var subtypeClasses: Array[Class[_]]              = Array.empty
-    private var subtypeSerializers: Array[TypeSerializer[_]] = Array.empty
+    private var subtypeClasses: Array[Class[_]] = Array.empty
 
     // An adapter is mandatory to keep the compatibility during the transition to a CompositeTypeSerializerSnapshot
     // because its readSnapshot() method is final
@@ -108,14 +107,13 @@ object CoproductSerializer {
         serializer.foreach { s =>
           // Scala limitation: can't call parent constructor used for writing the snapshot, reproduce its behavior instead
           subtypeClasses = s.subtypeClasses
-          subtypeSerializers = s.subtypeSerializers
           setNestedSerializersSnapshots(this, getNestedSerializers(s).map(_.snapshotConfiguration()): _*)
         }
 
         override def getCurrentOuterSnapshotVersion: Int = CurrentVersion
 
         override def getNestedSerializers(outerSerializer: CoproductSerializer[T]): Array[TypeSerializer[_]] =
-          subtypeSerializers
+          outerSerializer.subtypeSerializers
 
         override def createOuterSerializerWithNestedSerializers(
             nestedSerializers: Array[TypeSerializer[_]]
@@ -143,9 +141,11 @@ object CoproductSerializer {
           .map(_ => InstantiationUtil.resolveClassByName(in, userCodeClassLoader))
           .toArray
 
-        subtypeSerializers = (0 until len)
+        val subtypeSerializers = (0 until len)
           .map(_ => TypeSerializerSnapshot.readVersionedSnapshot(in, userCodeClassLoader).restoreSerializer())
           .toArray
+
+        setNestedSerializersSnapshots(adapter, subtypeSerializers.map(_.snapshotConfiguration()): _*)
       } else {
         adapter.readSnapshot(readVersion, in, userCodeClassLoader)
       }
@@ -157,12 +157,7 @@ object CoproductSerializer {
       case _                                   => TypeSerializerSchemaCompatibility.incompatible()
     }
 
-    override def restoreSerializer(): TypeSerializer[T] =
-      if (subtypeSerializers.isEmpty) {
-        adapter.restoreSerializer() // Restore from adapter
-      } else {
-        new CoproductSerializer[T](subtypeClasses, subtypeSerializers) // Restore from readSnapshot
-      }
+    override def restoreSerializer(): TypeSerializer[T] = adapter.restoreSerializer()
 
   }
 

--- a/modules/flink-common-api/src/main/scala/org/apache/flinkx/api/serializer/CoproductSerializer.scala
+++ b/modules/flink-common-api/src/main/scala/org/apache/flinkx/api/serializer/CoproductSerializer.scala
@@ -10,7 +10,7 @@ import org.apache.flink.api.common.typeutils.{
 }
 import org.apache.flink.core.memory.{DataInputView, DataOutputView}
 import org.apache.flink.util.InstantiationUtil
-import org.apache.flinkx.api.VariableLengthDataType
+import org.apache.flinkx.api.{NullMarkerByte, VariableLengthDataType}
 import org.apache.flinkx.api.serializer.CoproductSerializer.CoproductSerializerSnapshot
 import org.apache.flinkx.api.util.ClassUtil
 
@@ -51,34 +51,35 @@ class CoproductSerializer[T](val subtypeClasses: Array[Class[_]], val subtypeSer
   }
 
   override def serialize(record: T, target: DataOutputView): Unit = {
-    var subtypeIndex = 0
-    var found        = false
-    while (!found && (subtypeIndex < subtypeClasses.length)) {
-      if (subtypeClasses(subtypeIndex).isInstance(record)) {
-        found = true
-      } else {
-        subtypeIndex += 1
-      }
-    }
-    if (found) {
-      target.writeByte(subtypeIndex.toByte.toInt)
-      subtypeSerializers(subtypeIndex).asInstanceOf[TypeSerializer[T]].serialize(record, target)
+    if (record == null) {
+      target.writeByte(NullMarkerByte)
     } else {
-      throw new IllegalStateException("subtype not found in sealed trait schema")
+      val subtypeIndex = subtypeClasses.indexWhere(_.isInstance(record))
+      if (subtypeIndex >= 0) {
+        target.writeByte(subtypeIndex)
+        subtypeSerializers(subtypeIndex).asInstanceOf[TypeSerializer[T]].serialize(record, target)
+      } else {
+        throw new IllegalStateException("subtype not found in sealed trait schema")
+      }
     }
   }
 
   override def deserialize(source: DataInputView): T = {
-    val index   = source.readByte()
-    val subtype = subtypeSerializers(index.toInt)
-    subtype.asInstanceOf[TypeSerializer[T]].deserialize(source)
+    val index = source.readByte()
+    if (index == NullMarkerByte) {
+      null.asInstanceOf[T]
+    } else {
+      val subtype = subtypeSerializers(index)
+      subtype.asInstanceOf[TypeSerializer[T]].deserialize(source)
+    }
   }
 
   override def copy(source: DataInputView, target: DataOutputView): Unit = {
-    val index   = source.readByte()
-    val subtype = subtypeSerializers(index.toInt)
+    val index = source.readByte()
     target.writeByte(index)
-    subtype.asInstanceOf[TypeSerializer[T]].copy(source, target)
+    if (index != NullMarkerByte) {
+      subtypeSerializers(index).asInstanceOf[TypeSerializer[T]].copy(source, target)
+    }
   }
 
   override def snapshotConfiguration(): TypeSerializerSnapshot[T] =
@@ -151,7 +152,10 @@ object CoproductSerializer {
 
     override def resolveSchemaCompatibility(
         oldSerializerSnapshot: TypeSerializerSnapshot[T]
-    ): TypeSerializerSchemaCompatibility[T] = adapter.resolveSchemaCompatibility(oldSerializerSnapshot)
+    ): TypeSerializerSchemaCompatibility[T] = oldSerializerSnapshot match {
+      case oss: CoproductSerializerSnapshot[T] => adapter.resolveSchemaCompatibility(oss.adapter)
+      case _                                   => TypeSerializerSchemaCompatibility.incompatible()
+    }
 
     override def restoreSerializer(): TypeSerializer[T] =
       if (subtypeSerializers.isEmpty) {

--- a/modules/flink-common-api/src/test/scala/org/apache/flinkx/api/SerializerTest.scala
+++ b/modules/flink-common-api/src/test/scala/org/apache/flinkx/api/SerializerTest.scala
@@ -40,8 +40,8 @@ class SerializerTest extends AnyFlatSpec with Matchers with Inspectors with Test
   }
 
   it should "derive for ADTs" in {
-    testTypeInfoAndSerializer(Foo("a"), nullable = false)
-    testTypeInfoAndSerializer(Bar(1), nullable = false)
+    testTypeInfoAndSerializer(Foo("a"))
+    testTypeInfoAndSerializer(Bar(1))
   }
 
   it should "derive for ADTs with case objects" in {
@@ -54,7 +54,7 @@ class SerializerTest extends AnyFlatSpec with Matchers with Inspectors with Test
   }
 
   it should "derive for deeply nested adts" in {
-    testTypeInfoAndSerializer(Egg(1), nullable = false)
+    testTypeInfoAndSerializer(Egg(1))
   }
 
   it should "derive for nested ADTs" in {
@@ -63,7 +63,7 @@ class SerializerTest extends AnyFlatSpec with Matchers with Inspectors with Test
   }
 
   it should "derive for generic ADTs" in {
-    testTypeInfoAndSerializer(P2(1), nullable = false)
+    testTypeInfoAndSerializer(P2(1))
   }
 
   it should "derive seq" in {

--- a/modules/flink-common-api/src/test/scala/org/apache/flinkx/api/serializer/CoproductSerializerSnapshotTest.scala
+++ b/modules/flink-common-api/src/test/scala/org/apache/flinkx/api/serializer/CoproductSerializerSnapshotTest.scala
@@ -29,8 +29,11 @@ class CoproductSerializerSnapshotTest extends AnyFlatSpec with Matchers {
     val snapshotInput = new DataInputDeserializer(snapshotOutput.getSharedBuffer)
 
     // Deserialize SerializerSnapshot
-    val deserializedSnapshot = TypeSerializerSnapshot
-      .readVersionedSnapshot[SetSerializer[String]](snapshotInput, getClass.getClassLoader)
+    val deserializedSnapshot = TypeSerializerSnapshot.readVersionedSnapshot[ADT](snapshotInput, getClass.getClassLoader)
+
+    // Check the compatibility of the current snapshot with the restored snapshot
+    val compatibility = serializerSnapshot.resolveSchemaCompatibility(deserializedSnapshot)
+    compatibility.isIncompatible shouldBe false
 
     val deserializedSerializer = deserializedSnapshot.restoreSerializer()
     deserializedSerializer shouldNot be theSameInstanceAs expectedSerializer

--- a/modules/flink-common-api/src/test/scala/org/apache/flinkx/api/serializer/CoproductSerializerSnapshotTest.scala
+++ b/modules/flink-common-api/src/test/scala/org/apache/flinkx/api/serializer/CoproductSerializerSnapshotTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 
 class CoproductSerializerSnapshotTest extends AnyFlatSpec with Matchers {
 
-  it should "serialize then deserialize" in {
+  it should "serialize v3 then deserialize v3" in {
     // Create SerializerSnapshot
     val subtypeClasses: Array[Class[?]]              = Array(classOf[Foo], classOf[Bar])
     val subtypeSerializers: Array[TypeSerializer[?]] = Array(
@@ -38,6 +38,32 @@ class CoproductSerializerSnapshotTest extends AnyFlatSpec with Matchers {
     val deserializedSerializer = deserializedSnapshot.restoreSerializer()
     deserializedSerializer shouldNot be theSameInstanceAs expectedSerializer
     deserializedSerializer should be(expectedSerializer)
+  }
+
+  it should "serialize v2 then deserialize v3" in {
+    val subtypeClasses: Array[Class[?]]              = Array(classOf[Foo], classOf[Bar])
+    val subtypeSerializers: Array[TypeSerializer[?]] = Array(
+      implicitly[TypeSerializer[Foo]],
+      implicitly[TypeSerializer[Bar]]
+    )
+
+    // Write a v2 snapshot payload (as CoproductSerializerSnapshot#writeSnapshot did when v2 was current)
+    val out = new DataOutputSerializer(1024 * 1024)
+    out.writeInt(subtypeClasses.length)
+    subtypeClasses.foreach(c => out.writeUTF(c.getName))
+    subtypeSerializers.foreach(s => TypeSerializerSnapshot.writeVersionedSnapshot(out, s.snapshotConfiguration()))
+
+    // Restore the v2 snapshot as Flink would: no-arg constructor then readSnapshot with the persisted version
+    val oldSnapshot = new CoproductSerializer.CoproductSerializerSnapshot[ADT]()
+    oldSnapshot.readSnapshot(2, new DataInputDeserializer(out.getSharedBuffer), getClass.getClassLoader)
+
+    // Current (v3) snapshot for the same schema
+    val newSnapshot = new CoproductSerializer.CoproductSerializerSnapshot[ADT](
+      Some(new CoproductSerializer[ADT](subtypeClasses, subtypeSerializers))
+    )
+
+    val compatibility = newSnapshot.resolveSchemaCompatibility(oldSnapshot)
+    compatibility.isIncompatible shouldBe false
   }
 
 }


### PR DESCRIPTION
Hi @novakov-alexey,

Here is a small PR with two changes to `CoproductSerializer`:

- **Null handling**: sealed trait values could not be `null` before, `serialize()` would fail with `IllegalStateException("subtype not found in sealed trait schema")`. I added support for null values using `NullMarkerByte` marker.
  - I also refactored the subtype lookup in `serialize()` to use `indexWhere` instead of the manual while loop while I was there.

- **Fix in `CoproductSerializerSnapshot.resolveSchemaCompatibility()`**: I introduced a bug in PR https://github.com/flink-extended/flink-scala-api/pull/358 when I added the `CompositeTypeSerializerSnapshot` adapter. The old snapshot passed to `resolveSchemaCompatibility` is a `CoproductSerializerSnapshot`, but I was forwarding it directly to `adapter.resolveSchemaCompatibility(...)` which expects a `CompositeTypeSerializerSnapshot` (i.e. the inner adapter). This caused schema compatibility checks between two `CoproductSerializerSnapshot`s to return `incompatible`. Instead, the fix forwards the old snapshot `adapter`, and falls back to `incompatible()` for any other snapshot type as expected.
  - It's still a bit uncertain to me when Flink calls `SerializerSnapshot.resolveSchemaCompatibility()` but I think it can occur when deserializing an object used as a key in `KeyedProcessFunction`, etc. It's worth to fix before it hurts someone!

Sorry to have seen this only after you made a new release.

Thanks