### PR TITLE
Migrate the build to sbt 2.0.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,15 @@ jobs:
       - name: Compile Scala 2.13 Docs
         if: matrix.sbt-module == 'flink-1-api2_13'
         run: sbt docs2_13/mdoc
+      # The whole point of this row is to exercise an older JDK than the one sbt runs on. `Test / javaHome`
+      # falls back to sbt's own JDK when TEST_JAVA_HOME is unset, and the tests would then pass while
+      # checking nothing, so refuse to run rather than report a green build that proves the wrong thing.
+      - name: Check that the test JDK is resolved
+        run: |
+          : "${TEST_JAVA_HOME:?not set - JAVA_HOME_${{ matrix.java }}_X64 did not resolve}"
+          "$TEST_JAVA_HOME/bin/java" -version
+        env:
+          TEST_JAVA_HOME: ${{ env[format('JAVA_HOME_{0}_X64', matrix.java)] }}
       - name: Run tests on ${{ matrix.sbt-module }}
         run: sbt ${{ matrix.sbt-module }}/testFull
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,10 @@ jobs:
   # Job 1: Full test coverage (all projects)
   java-17-full:
     runs-on: ubuntu-22.04
+    # sbt 2 reuses the server started by the first invocation, so JAVA_OPTS has to be set for the whole job
+    # rather than per step - a later step's environment never reaches the already running server.
     env:
-      JAVA_OPTIONS: '--add-opens java.base/java.lang=ALL-UNNAMED'
+      JAVA_OPTS: '--add-opens java.base/java.lang=ALL-UNNAMED'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -29,13 +31,13 @@ jobs:
           java-version: 17
           cache: sbt
       - name: Run all tests
-        run: JAVA_OPTS=$JAVA_OPTIONS sbt test
+        run: sbt testFull
       - name: Check the binary compatibility with the previous release
-        run: JAVA_OPTS=$JAVA_OPTIONS sbt mimaReportBinaryIssues
-      - name: Compile Scala 2.13 docs
-        run: JAVA_OPTS=$JAVA_OPTIONS sbt docs/mdoc
+        run: sbt mimaReportBinaryIssues
       - name: Compile Scala 3 docs
-        run: JAVA_OPTS=$JAVA_OPTIONS sbt docs3/mdoc
+        run: sbt docs/mdoc
+      - name: Compile Scala 2.13 docs
+        run: sbt docs2_13/mdoc
 
   # Job 2: Matrix builds for Java version compatibility (Java 17 is already tested with java-17-full)
   java-compat:
@@ -43,36 +45,45 @@ jobs:
     strategy:
       matrix:
         java: [11]
-        sbt-module: ['flink-1-api-common', 'flink-1-api-common3', 'flink-1-api', 'flink-1-api3']
+        sbt-module: ['flink-1-api-common', 'flink-1-api-common2_13', 'flink-1-api', 'flink-1-api2_13']
         include:
           - java: 21
             sbt-module: 'flink-2-api-common'
           - java: 21
-            sbt-module: 'flink-2-api-common3'
+            sbt-module: 'flink-2-api-common2_13'
           - java: 21
             sbt-module: 'flink-2-api'
           - java: 21
-            sbt-module: 'flink-2-api3'
+            sbt-module: 'flink-2-api2_13'
     env:
-      JAVA_OPTIONS: '--add-opens java.base/java.lang=ALL-UNNAMED'
+      JAVA_OPTS: '--add-opens java.base/java.lang=ALL-UNNAMED'
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Set up JDK ${{ matrix.java }}
+      # sbt 2 requires JDK 17+, so sbt runs on 17 (listed last, hence the default JAVA_HOME) while the
+      # forked test JVM runs on the JDK whose compatibility this row is meant to check.
+      - name: Set up JDK ${{ matrix.java }} and 17
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: ${{ matrix.java }}
+          java-version: |
+            ${{ matrix.java }}
+            17
           cache: sbt
-      - name: Compile Scala 2.13 Docs
-        if: matrix.sbt-module == 'flink-1-api'
-        run: JAVA_OPTS=$JAVA_OPTIONS sbt "docs/mdoc"
       - name: Compile Scala 3 Docs
-        if: matrix.sbt-module == 'flink-1-api3'
-        run: JAVA_OPTS=$JAVA_OPTIONS sbt "docs3/mdoc"
+        if: matrix.sbt-module == 'flink-1-api'
+        run: sbt docs/mdoc
+      - name: Compile Scala 2.13 Docs
+        if: matrix.sbt-module == 'flink-1-api2_13'
+        run: sbt docs2_13/mdoc
       - name: Run tests on ${{ matrix.sbt-module }}
-        run: JAVA_OPTS=$JAVA_OPTIONS sbt "project ${{ matrix.sbt-module }}; test"
+        run: sbt ${{ matrix.sbt-module }}/testFull
+        env:
+          TEST_JAVA_HOME: ${{ env[format('JAVA_HOME_{0}_X64', matrix.java)] }}
+      # `examples` is a Scala 3 only project, so it rides along with the Scala 3 flink-1 row
       - name: Run tests on examples
-        if: matrix.sbt-module == 'flink-1-api3'
-        run: JAVA_OPTS=$JAVA_OPTIONS sbt "project examples3; test"
+        if: matrix.sbt-module == 'flink-1-api'
+        run: sbt examples/testFull
+        env:
+          TEST_JAVA_HOME: ${{ env[format('JAVA_HOME_{0}_X64', matrix.java)] }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,11 @@ jobs:
   # Job 1: Full test coverage (all projects)
   java-17-full:
     runs-on: ubuntu-22.04
-    # sbt 2 reuses the server started by the first invocation, so JAVA_OPTS has to be set for the whole job
-    # rather than per step - a later step's environment never reaches the already running server.
+    # A wedged sbt server produces no output at all, so fail fast rather than sit on a runner for hours
+    timeout-minutes: 30
+    # sbt 2 runs as a daemon that outlives the step that started it. A later step's sbtn then attaches to
+    # that server, which has been seen to hang with no output at all, and never sees this step's environment
+    # either - so JAVA_OPTS is set for the whole job and every sbt invocation ends with `shutdown`.
     env:
       JAVA_OPTS: '--add-opens java.base/java.lang=ALL-UNNAMED'
     steps:
@@ -31,17 +34,18 @@ jobs:
           java-version: 17
           cache: sbt
       - name: Run all tests
-        run: sbt testFull
+        run: sbt "testFull; shutdown"
       - name: Check the binary compatibility with the previous release
-        run: sbt mimaReportBinaryIssues
+        run: sbt "mimaReportBinaryIssues; shutdown"
       - name: Compile Scala 3 docs
-        run: sbt docs/mdoc
+        run: sbt "docs/mdoc; shutdown"
       - name: Compile Scala 2.13 docs
-        run: sbt docs2_13/mdoc
+        run: sbt "docs2_13/mdoc; shutdown"
 
   # Job 2: Matrix builds for Java version compatibility (Java 17 is already tested with java-17-full)
   java-compat:
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     strategy:
       matrix:
         java: [11]
@@ -73,10 +77,10 @@ jobs:
           cache: sbt
       - name: Compile Scala 3 Docs
         if: matrix.sbt-module == 'flink-1-api'
-        run: sbt docs/mdoc
+        run: sbt "docs/mdoc; shutdown"
       - name: Compile Scala 2.13 Docs
         if: matrix.sbt-module == 'flink-1-api2_13'
-        run: sbt docs2_13/mdoc
+        run: sbt "docs2_13/mdoc; shutdown"
       # The whole point of this row is to exercise an older JDK than the one sbt runs on. `Test / javaHome`
       # falls back to sbt's own JDK when TEST_JAVA_HOME is unset, and the tests would then pass while
       # checking nothing, so refuse to run rather than report a green build that proves the wrong thing.
@@ -87,12 +91,12 @@ jobs:
         env:
           TEST_JAVA_HOME: ${{ env[format('JAVA_HOME_{0}_X64', matrix.java)] }}
       - name: Run tests on ${{ matrix.sbt-module }}
-        run: sbt ${{ matrix.sbt-module }}/testFull
+        run: sbt "${{ matrix.sbt-module }}/testFull; shutdown"
         env:
           TEST_JAVA_HOME: ${{ env[format('JAVA_HOME_{0}_X64', matrix.java)] }}
       # `examples` is a Scala 3 only project, so it rides along with the Scala 3 flink-1 row
       - name: Run tests on examples
         if: matrix.sbt-module == 'flink-1-api'
-        run: sbt examples/testFull
+        run: sbt "examples/testFull; shutdown"
         env:
           TEST_JAVA_HOME: ${{ env[format('JAVA_HOME_{0}_X64', matrix.java)] }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,11 @@ jobs:
     runs-on: ubuntu-22.04
     # A wedged sbt server produces no output at all, so fail fast rather than sit on a runner for hours
     timeout-minutes: 30
-    # sbt 2 runs as a daemon that outlives the step that started it. A later step's sbtn then attaches to
-    # that server, which has been seen to hang with no output at all, and never sees this step's environment
-    # either - so JAVA_OPTS is set for the whole job and every sbt invocation ends with `shutdown`.
+    # sbt 2 defaults to a thin client talking to a daemon that outlives the step that started it. That cost
+    # us a step which attached to a stale server and hung for hours without printing a line, and mdoc runs
+    # sent back to the client for forking (NoClassDefFoundError from clientSideRun). `--server` skips the
+    # client and the daemon: every step is a self-contained sbt process, as it was under sbt 1. JAVA_OPTS
+    # stays at job level so it cannot be missed by a step either way.
     env:
       JAVA_OPTS: '--add-opens java.base/java.lang=ALL-UNNAMED'
     steps:
@@ -34,13 +36,13 @@ jobs:
           java-version: 17
           cache: sbt
       - name: Run all tests
-        run: sbt "testFull; shutdown"
+        run: sbt --server -batch "testFull"
       - name: Check the binary compatibility with the previous release
-        run: sbt "mimaReportBinaryIssues; shutdown"
+        run: sbt --server -batch "mimaReportBinaryIssues"
       - name: Compile Scala 3 docs
-        run: sbt "docs/mdoc; shutdown"
+        run: sbt --server -batch "docs/mdoc"
       - name: Compile Scala 2.13 docs
-        run: sbt "docs2_13/mdoc; shutdown"
+        run: sbt --server -batch "docs2_13/mdoc"
 
   # Job 2: Matrix builds for Java version compatibility (Java 17 is already tested with java-17-full)
   java-compat:
@@ -77,10 +79,10 @@ jobs:
           cache: sbt
       - name: Compile Scala 3 Docs
         if: matrix.sbt-module == 'flink-1-api'
-        run: sbt "docs/mdoc; shutdown"
+        run: sbt --server -batch "docs/mdoc"
       - name: Compile Scala 2.13 Docs
         if: matrix.sbt-module == 'flink-1-api2_13'
-        run: sbt "docs2_13/mdoc; shutdown"
+        run: sbt --server -batch "docs2_13/mdoc"
       # The whole point of this row is to exercise an older JDK than the one sbt runs on. `Test / javaHome`
       # falls back to sbt's own JDK when TEST_JAVA_HOME is unset, and the tests would then pass while
       # checking nothing, so refuse to run rather than report a green build that proves the wrong thing.
@@ -91,12 +93,12 @@ jobs:
         env:
           TEST_JAVA_HOME: ${{ env[format('JAVA_HOME_{0}_X64', matrix.java)] }}
       - name: Run tests on ${{ matrix.sbt-module }}
-        run: sbt "${{ matrix.sbt-module }}/testFull; shutdown"
+        run: sbt --server -batch "${{ matrix.sbt-module }}/testFull"
         env:
           TEST_JAVA_HOME: ${{ env[format('JAVA_HOME_{0}_X64', matrix.java)] }}
       # `examples` is a Scala 3 only project, so it rides along with the Scala 3 flink-1 row
       - name: Run tests on examples
         if: matrix.sbt-module == 'flink-1-api'
-        run: sbt "examples/testFull; shutdown"
+        run: sbt --server -batch "examples/testFull"
         env:
           TEST_JAVA_HOME: ${{ env[format('JAVA_HOME_{0}_X64', matrix.java)] }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,14 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           cache: sbt
       - uses: sbt/setup-sbt@v1
       - run: sudo apt update && sudo apt install -y gnupg
       - run: echo $PGP_SECRET | base64 --decode | gpg --batch --import
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
-      - run: sbt test ciReleaseSonatype
+      - run: sbt "testFull; ciReleaseSonatype"
         env:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - run: echo $PGP_SECRET | base64 --decode | gpg --batch --import
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
-      - run: sbt "testFull; ciReleaseSonatype; shutdown"
+      - run: sbt --server -batch "testFull; ciReleaseSonatype"
         env:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - run: echo $PGP_SECRET | base64 --decode | gpg --batch --import
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
-      - run: sbt "testFull; ciReleaseSonatype"
+      - run: sbt "testFull; ciReleaseSonatype; shutdown"
         env:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,20 @@ import com.typesafe.tools.mima.core.{
 }
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
+
+// sbt 2 hands forked tests a "virtual" classpath that the JVM's own class loader cannot see, which breaks
+// Flink's user-code class loader (ClassNotFoundException on Flink classes). Raw puts the classpath back on
+// the forked JVM's -cp. Flink's MiniCluster and the type-derivation cache are also not safe to share between
+// suites running concurrently in one JVM, so suites run one at a time.
+Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Raw
+// sbt 2.0.5 closes test class loaders when the task completes; ScalaTest's reporter then fails to read its
+// own resource bundle while printing the run summary.
+Global / closeClassLoaders          := false
+Test / parallelExecution           := false
+
+// sbt 2 itself needs JDK 17+, so CI can no longer check older JDKs simply by running sbt on them.
+// When TEST_JAVA_HOME points at another JDK, the forked test JVM uses it instead.
+Test / javaHome := sys.env.get("TEST_JAVA_HOME").filter(_.nonEmpty).map(file)
 Global / excludeLintKeys      := Set(crossScalaVersions)
 
 lazy val rootScalaVersion = "3.3.8"
@@ -16,14 +30,12 @@ lazy val flinkVersion2    = System.getProperty("flinkVersion2", "2.0.0")
 // Version on which the binary compatibility is checked by MiMa
 lazy val mimaPreviousVersion = "2.2.4"
 
-ThisBuild / publishTo := sonatypePublishToBundle.value
+ThisBuild / publishTo := localStaging.value
 
 inThisBuild(
   List(
     organization := "com.github.sbt",
     homepage     := Some(url("https://github.com/sbt/sbt-ci-release")),
-    // Alternatively License.Apache2 see https://github.com/sbt/librarymanagement/blob/develop/core/src/main/scala/sbt/librarymanagement/License.scala
-    licenses   := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
     developers := List(
       Developer(
         id = "romangrebennikov",
@@ -46,9 +58,8 @@ inThisBuild(
     ),
     organization           := "org.flinkextended",
     description            := "Community-maintained fork of official Apache Flink Scala API",
-    licenses               := Seq("APL2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")),
-    homepage               := Some(url("https://github.com/flink-extended/flink-scala-api")),
-    sonatypeCredentialHost := "central.sonatype.com"
+    licenses               := Seq(License.Apache2),
+    homepage               := Some(url("https://github.com/flink-extended/flink-scala-api"))
   )
 )
 
@@ -57,7 +68,7 @@ lazy val `flink-scala-api` = (project in file("."))
     `flink`.projectRefs ++
       `flink-1-api`.projectRefs ++
       `flink-2-api`.projectRefs ++
-      `examples`.projectRefs: _*
+      `examples`.projectRefs*
   )
   .settings(commonSettings)
   .settings(
@@ -86,11 +97,13 @@ lazy val commonSettings = Seq(
   Test / fork := true,
   // Need to isolate macro usage to version-specific folders.
   Compile / unmanagedSourceDirectories += {
-    val dir              = (Compile / scalaSource).value.getPath
-    val Some((major, _)) = CrossVersion.partialVersion(scalaVersion.value)
+    val dir   = (Compile / scalaSource).value.getPath
+    val major = CrossVersion.partialVersion(scalaVersion.value).map(_._1).getOrElse(sys.error("no Scala version"))
     file(s"$dir-$major")
   },
   scalacOptions ++= Seq(
+    // sbt 2 requires JDK 17+, but the published artifacts must stay loadable on Java 11.
+    "-release:11",
     "-deprecation",
     "-feature",
     "-language:higherKinds",
@@ -222,7 +235,7 @@ lazy val `examples` = (projectMatrix in file("modules/examples"))
       "io.bullet"       %% "borer-core"                 % "1.18.0"      % Provided,
       "ch.qos.logback"   % "logback-classic"            % "1.4.14"      % Provided,
       "org.apache.flink" % "flink-test-utils"           % flinkVersion1 % Test,
-      "org.apache.flink" % "flink-streaming-java"       % flinkVersion1 % Test classifier "tests",
+      ("org.apache.flink" % "flink-streaming-java"      % flinkVersion1 % Test).classifier("tests"),
       "org.typelevel"   %% "cats-core"                  % "2.13.0"      % Test,
       "org.scalatest"   %% "scalatest"                  % "3.2.15"      % Test
     ),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.12.14
+sbt.version = 2.0.5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,5 @@
 addSbtPlugin("org.scalameta"  % "sbt-scalafmt"         % "2.6.2")
 addSbtPlugin("org.scalameta"  % "sbt-mdoc"             % "2.9.2")
 addSbtPlugin("com.github.sbt" % "sbt-protobuf"         % "0.8.3")
-addSbtPlugin("io.shiftleft"   % "sbt-ci-release-early" % "2.1.11")
-addSbtPlugin("com.eed3si9n"   % "sbt-projectmatrix"    % "0.11.0")
+addSbtPlugin("io.shiftleft"   % "sbt-ci-release-early" % "2.1.15")
 addSbtPlugin("com.typesafe"   % "sbt-mima-plugin"      % "1.1.6")


### PR DESCRIPTION
Replaces #411, which was a Scala Steward bump of `project/build.properties` alone — sbt 2 needs rather more than that.

## Plugins

`sbt-projectmatrix` is **dropped**: it has no sbt 2 build and no longer needs one, because sbt 2.0 in-sourced project matrix with the same API (`projectMatrix`, `customRow`, `jvmPlatform`, `projectRefs`, `VirtualAxis`). `project/FlinkAxis.scala` compiles unchanged.

Every other plugin is already cross-published for sbt 2 (`_sbt2_3`) at the version we pin. Only `sbt-ci-release-early` moves, 2.1.11 → 2.1.15.

## Publishing

`sbt-ci-release-early` 2.1.15 dropped its `sbt-sonatype` dependency, and `sbt-sonatype` is not published for sbt 2 final anyway — the legacy Sonatype API it was built on is gone. Publishing therefore moves to sbt's native Central support:

- `publishTo := sonatypePublishToBundle.value` → `localStaging.value`
- `sonatypeCredentialHost` removed — under sbt 2 credentials come from `SONATYPE_USERNAME`/`SONATYPE_PASSWORD` automatically
- `ciReleaseSonatype` still exists and now drives the native `sonaRelease`

Checked locally: `flink-1-api/publish` produces `flink-scala-api-1_3` with a Central-compliant POM (licenses, scm, developers, dynver version).

## Scala 3 build DSL

sbt 2's `build.sbt` is Scala 3, so: vararg splice `: _*` → `*`, the refutable `val Some((major, _)) = ...` pattern, infix `classifier`, `licenses` is now `Seq[License]`. The duplicate `licenses`/`homepage` settings this file carried are gone.

## Three sbt 2 behaviour changes that needed settings

- **`Test / classLoaderLayeringStrategy := Raw`.** sbt 2 forks tests with an empty `-cp` and hands the classpath to the worker as a virtual list. Flink's user-code class loader delegates to the app class loader, which then has nothing on it, and every MiniCluster test dies with `ClassNotFoundException: org.apache.flink.api.common.ExecutionConfig`. `Raw` is the only strategy that puts the classpath back on the forked JVM's `-cp` (`Flat` does not).
- **`Global / closeClassLoaders := false`.** As of 2.0.5 test class loaders are closed when the task completes, after which ScalaTest's reporter cannot read its own resource bundle. It looks flaky because the bundle is only needed for the "one minute" summary string.
- **`Test / parallelExecution := false`.** Suites now share a forked JVM concurrently, which Flink's MiniCluster and the type-derivation cache do not tolerate.

## JDK and CI

sbt 2 requires JDK 17+ (its own class files are major 61), which has two consequences:

- The release job moves to JDK 17, so **`-release:11`** is now needed to keep publishing Java 11 bytecode. Verified: emitted class files are still major 55.
- The Java 11/21 compat matrix can no longer be expressed by running sbt on those JDKs. Both JDKs are installed, sbt runs on 17, and `TEST_JAVA_HOME` points the forked test JVM at the JDK under test.

Also in CI: project ids changed (sbt 2 suffixes the Scala **2.13** rows, not the Scala 3 ones — `flink-1-api2_13`, `docs2_13`, and plain `examples`), command sequences must be quoted (`sbt "testFull; ciReleaseSonatype"`), `JAVA_OPTS` must be set at job level because later steps reuse the server started by the first one, and `test` is now incremental so CI uses `testFull`.

## Verification

Locally, from a clean `target/`, on JDK 17:

- `testFull` — 882 tests, 0 failures, across all 9 rows
- `mimaReportBinaryIssues`
- `docs/mdoc` and `docs2_13/mdoc`
- `scalafmtCheckAll`

The workflow changes themselves are unexercised until this PR runs.
