### PR TITLE
Stop branch pushes triggering CI twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,12 @@
 name: All Tests
 
 on:
+  # Only master, because a branch pushed to this repo would otherwise trigger this workflow twice: once for
+  # the push and once for the pull request. Both land in the same concurrency group below, so one run gets
+  # cancelled and the PR shows nine cancelled checks alongside the nine that ran. Pull requests from forks,
+  # which never fire a push event here, were always unaffected.
   push:
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
#420 and #422 each showed nine red checks next to nine green ones. Nothing was failing: the red ones were **cancelled**, which GitHub renders the same way.

A branch pushed to this repo fires both `push` and `pull_request`. The concurrency group resolves to the same string for both — `head_ref` is empty on a push, so it falls back to `ref_name` — and with `cancel-in-progress: true` whichever run starts second kills the first.

This never showed up before because Scala Steward pushes to a fork (`scala-steward/flink-scala-api-1`), and a push to a fork does not fire a push event in this repo. Only branches pushed directly here hit it, which nobody had done for a while.

Restricting `push` to `master` keeps the post-merge run on master and leaves fork pull requests untouched.

The fix applies to itself: a `push` event is matched against the workflow file at the pushed commit, so this branch already stops triggering the duplicate. This PR should show nine checks, not eighteen.